### PR TITLE
build: small fixes & enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ export PACKAGE      := CLUB1
 export VERSION      := main
 export EMAIL        := nicolas@club1.fr
 
-export LANGUAGE     := fr
-export LANGUAGES    := $(LANGUAGE) $(LOCALES)
+export LOCALE       := fr
+export LANGUAGES    := $(LOCALE) $(LOCALES)
 export LATEXMKOPTS  := -quiet
 
 SPHINXLANG      := -D language=$(LOCALE)
@@ -19,7 +19,7 @@ SPHINXOPTS      += -a $(if $(CI),,-q)
 SPHINXBUILD     ?= sphinx-build
 SPHINXBUILDERS  := html dirhtml singlehtml epub latex text man texinfo
 SPHINXLBUILDERS := $(foreach b,$(SPHINXBUILDERS),$(LANGUAGES:%=$b/%))
-SPHINXCMDS      := gettext pickle json htmlhelp changes xml pseudoxml linkcheck doctest coverage
+SPHINXCMDS      := gettext changes xml pseudoxml linkcheck
 SOURCEDIR       := .
 BUILDDIR        := _build
 
@@ -28,7 +28,7 @@ PUBDIR          ?= /var/www/docs
 
 # Put it first so that "make" without argument is like "make help".
 help:
-	$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $O
+	$(SPHINXBUILD) -M help $(SOURCEDIR) $(BUILDDIR) $(SPHINXOPTS) $O
 
 .PHONY: help clean update-po latexpdf info publish $(SPHINXBUILDERS) $(SPHINXLBUILDERS) $(SPHINXCMDS)
 
@@ -66,11 +66,11 @@ $(SPHINXBUILDERS): %: $(LANGUAGES:%=\%/%);
 # Localized Sphinx builders
 .SECONDEXPANSION:
 $(SPHINXLBUILDERS): $$(if $$(filter fr,$$(@F)),,locales/$$(@F)/LC_MESSAGES/package.mo locales/$$(@F)/LC_MESSAGES/sphinx.mo)
-	LANGUAGE=$(@F) $(SPHINXBUILD) -b $(@D) "$(SOURCEDIR)" "$(BUILDDIR)/$(@D)/$(@F)" $(SPHINXOPTS) $O
+	LOCALE=$(@F) $(SPHINXBUILD) -b $(@D) -d $(BUILDDIR)/doctrees/$(@F) $(SOURCEDIR) $(BUILDDIR)/$(@D)/$(@F) $(SPHINXOPTS) $O
 
 # Other Sphinx commands for autocompletion
 $(SPHINXCMDS):
-	$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $O
+	$(SPHINXBUILD) -M $@ $(SOURCEDIR) $(BUILDDIR) $(SPHINXOPTS) $O
 
 clean:
 	rm -f locales/*/LC_MESSAGES/*.mo

--- a/conf.py
+++ b/conf.py
@@ -51,7 +51,7 @@ templates_path = ['_templates']
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = os.environ['LANGUAGE']
+language = os.environ['LOCALE']
 
 # Set by make.
 languages = os.environ['LANGUAGES'].split(' ')
@@ -81,6 +81,9 @@ image_converter_args = ['-density', '250', '-resize', '230%']
 # Disable smart quotes at Sphinx level, as it is done by MyST.
 smartquotes = False
 
+# Date formats for today, for instance in LaTeX.
+# Use locale’s appropriate date representation.
+today_fmt = '%x'
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -119,7 +122,16 @@ html_static_path = ['_static']
 # The domain is used for code documentation, so no need for it here.
 primary_domain = None
 
+
 # -- Options for MAN output --------------------------------------------------
 
 # Show URLs after text in MAN output.
 man_show_urls = True
+
+
+# -- Options for LATEX output ------------------------------------------------
+
+# Always use A4 paper.
+latex_elements = {
+    'papersize': 'a4paper',
+}


### PR DESCRIPTION
- rename LANGUAGE exported env var to LOCAL, not to disturb Make messages
- remove failing sphinx commands
- remove quotes around BUILDDIR and SOURCEDIR as these will never have spaces
- share doctrees for localized builders for perf. This also fixes warning for epub
  about .doctrees unknown mimetype
- fix LaTeX paper size to always use A4
- fix today format to use a localized version
