### PR TITLE
feat: add very basic index template

### DIFF
--- a/_templates/index.html
+++ b/_templates/index.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+	<title>Index of /docs/</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
+</head>
+<body>
+	<h1>Index of /docs/</h1>
+	<hr/>
+
+<pre>
+<a href="en/">en/</a>
+<a href="fr/">fr/</a>
+</pre>
+
+	<hr/>
+</body>
+</html>


### PR DESCRIPTION
It based on nginx's one, with the meta viewport added, as it is not there by default
(see https://mailman.nginx.org/pipermail/nginx-devel/2020-November/013609.html)

It could be customized later.


### Before

![2022-04-29-133031_333x581_scrot](https://user-images.githubusercontent.com/23519418/165936424-7fa55df1-34d6-4492-a14d-3ab89cf12e74.png)

### After

![2022-04-29-133019_341x588_scrot](https://user-images.githubusercontent.com/23519418/165936420-6675cad4-ff35-4b6b-ab69-8a544dc11916.png)

