### PR TITLE
docs: ajout d'une astuce Git dans la meta-doc

### DIFF
--- a/interne/meta-doc.md
+++ b/interne/meta-doc.md
@@ -66,6 +66,12 @@ pour qu'elles soient intégrées à la branche principale.
 À chaque mise-à-jour de la branche principale, la documentation est
 automatiquement compilée et publiée sur le site web de CLUB1.
 
+```{tip}
+Git détecte les modifications par ligne, il est donc intéressant de souvent retourner à la ligne.
+Par exemple à chaque nouvelle phrase, ou entre deux propositions d'une même phrase.
+Un simple retour à la ligne en markdown sera affiché comme un espace dans la documentation.
+```
+
 ### Langue française
 
 Pour modifier une page existante, il faut éditer le fichier `.md` correspondant.

--- a/interne/meta-doc.md
+++ b/interne/meta-doc.md
@@ -67,8 +67,10 @@ pour qu'elles soient intégrées à la branche principale.
 automatiquement compilée et publiée sur le site web de CLUB1.
 
 ```{tip}
-Git détecte les modifications par ligne, il est donc intéressant de souvent retourner à la ligne.
-Par exemple à chaque nouvelle phrase, ou entre deux propositions d'une même phrase.
+Git regroupe les modifications par ligne.
+Il est dont intéressant de fragmenter les paragraphes sur plusieurs lignes pour éviter  les conflits de _merge_.
+Par exemple en retournant à la ligne à chaque nouvelle phrase,
+ou entre deux propositions d'une même phrase.
 Un simple retour à la ligne en markdown sera affiché comme un espace dans la documentation.
 ```
 


### PR DESCRIPTION
Qui conseille de souvent faire des retours à la ligne