### PR TITLE
pdf: customizations including emojis and admonition colors

### DIFF
--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -1,4 +1,16 @@
-\ProvidesPackage{club1}[2022/05/17 CLUB1's Sphinx customizations LaTeX package]
+% Paquet LaTeX permettant de customiser le rendu du PDF.
+\ProvidesPackage{club1}[2022/05/17 Customisations LaTeX CLUB1]
+
+% Définition du point médian.
+% La commande \textperiodcentered créé un point médian mais entouré
+% d'espaces : "cher{\textperiodcentered}es" devient "cher · es".
+% Le problème est le même si l'on saisit directement le caractère
+% "middle dot" (U+00B7): "cher·es" devient "cher · es".
+% On remplace donc ce caractère par \cdot.
+\RequirePackage{newunicodechar}
+\newunicodechar{·}{\cdot}
+
+% Définition des paramètres de rendu de Sphinx.
 \sphinxsetup{
 	verbatimwithframe=true,
 	VerbatimColor={named}{MintCream},

--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -22,6 +22,9 @@
 \RequirePackage{newunicodechar}
 \newunicodechar{·}{\cdot}
 
+% Augmentation de la DPI des images qui ne l'ont pas définie.
+\pdfimageresolution=140
+
 % Définition des paramètres de rendu de Sphinx.
 \sphinxsetup{
 	verbatimwithframe=true,

--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -1,6 +1,18 @@
 % Paquet LaTeX permettant de customiser le rendu du PDF.
 \ProvidesPackage{club1}[2022/05/17 Customisations LaTeX CLUB1]
 
+% Définition de NotoColorEmoji comme police de substitution
+% pour pouvoir l'utiliser lorsque des caractères sont introuvables,
+% notamment lorsqu'il s'agit d'emojis.
+\directlua{
+	luaotfload.add_fallback("emoji", {"NotoColorEmoji:mode=harf;"})
+}
+% Définition des polices du document,
+% en spécifiant la police de substitution.
+\setmainfont{LatinModernRoman}[RawFeature={fallback=emoji}]
+\setsansfont{LatinModernSans}[RawFeature={fallback=emoji}]
+\setmonofont{DejaVuSansMono}[RawFeature={fallback=emoji},Scale=0.8]
+
 % Définition du point médian.
 % La commande \textperiodcentered créé un point médian mais entouré
 % d'espaces : "cher{\textperiodcentered}es" devient "cher · es".

--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -1,0 +1,18 @@
+\ProvidesPackage{club1}[2022/05/17 CLUB1's Sphinx customizations LaTeX package]
+\sphinxsetup{
+	verbatimwithframe=true,
+	VerbatimColor={named}{MintCream},
+	% TitleColor={named}{DarkGoldenrod},
+	noteBorderColor={named}{SteelBlue},
+	tipBorderColor={named}{LightSeaGreen},
+	importantBorderColor={named}{LightSeaGreen},
+	dangerBorderColor={named}{Crimson},
+	dangerBgColor={named}{MistyRose},
+	cautionBorderColor={named}{Orange},
+	cautionBgColor={named}{LemonChiffon},
+	attentionBorderColor={named}{Orange},
+	attentionBgColor={named}{LemonChiffon},
+	warningBorderColor={named}{Orange},
+	warningBgColor={named}{LemonChiffon}
+}
+

--- a/conf.py
+++ b/conf.py
@@ -163,6 +163,4 @@ latex_elements = {
     'passoptionstopackages': r'\PassOptionsToPackage{svgnames}{xcolor}',
     # Add custom preamble.
     'preamble': r'\usepackage{club1}',
-    # Make sure to use fontspec package for fonts.
-    'fontpkg': r'\usepackage{fontspec}',
 }

--- a/conf.py
+++ b/conf.py
@@ -157,8 +157,6 @@ latex_additional_files = ['_templates/club1.sty']
 latex_elements = {
     # Always use A4 paper.
     'papersize': 'a4paper',
-    # Increase default DPI of images to make them smaller.
-    'pxunit': '0.53bp',
     # Make sure to use babel instead of polyglossia.
     'babel': r'\usepackage{babel}',
     # Use names for colors.

--- a/conf.py
+++ b/conf.py
@@ -143,10 +143,14 @@ man_show_urls = True
 
 # -- Options for LATEX output ------------------------------------------------
 
-# Use LuaLaTeX for Unicode support, especially emojis
+# Use LuaLaTeX for Unicode support, especially emojis.
 latex_engine = 'lualatex'
 
+# Add footnote for external URLs, useful for printed copies.
 latex_show_urls = 'footnote'
+
+# Show pages for internal refs, useful for printed copies.
+latex_show_pagerefs = True
 
 latex_additional_files = ['_templates/club1.sty']
 
@@ -155,17 +159,12 @@ latex_elements = {
     'papersize': 'a4paper',
     # Increase default DPI of images to make them smaller.
     'pxunit': '0.53bp',
-    # Use for sure babel instead of polyglossia.
+    # Make sure to use babel instead of polyglossia.
     'babel': r'\usepackage{babel}',
     # Use names for colors.
     'passoptionstopackages': r'\PassOptionsToPackage{svgnames}{xcolor}',
     # Add custom preamble.
     'preamble': r'\usepackage{club1}',
-    # Set fallback fonts to Noto to support emojis.
-    'fontpkg': r'''
-\directlua{luaotfload.add_fallback("emoji", {"NotoColorEmoji:mode=harf;"})}
-\setmainfont{LatinModernRoman}[RawFeature={fallback=emoji}]
-\setsansfont{LatinModernSans}[RawFeature={fallback=emoji}]
-\setmonofont{DejaVuSansMono}[RawFeature={fallback=emoji},Scale=0.8]
-''',
+    # Make sure to use fontspec package for fonts.
+    'fontpkg': r'\usepackage{fontspec}',
 }

--- a/conf.py
+++ b/conf.py
@@ -143,19 +143,19 @@ man_show_urls = True
 
 # -- Options for LATEX output ------------------------------------------------
 
-# Use XeLaTeX for Unicode support, especially emojis
-latex_engine = 'xelatex'
+# Use LuaLaTeX for Unicode support, especially emojis
+latex_engine = 'lualatex'
 
 latex_show_urls = 'footnote'
 
 latex_elements = {
     # Always use A4 paper.
     'papersize': 'a4paper',
-    # Customize fonts.
+    # Set fallback fonts to Noto to support emojis.
     'fontpkg': r'''
-\usepackage{fontspec}
-\setmainfont{DejaVu Serif}
-\setsansfont{DejaVu Sans}
-\setmonofont{DejaVu Sans Mono}
+\directlua{luaotfload.add_fallback("emoji", {"NotoColorEmoji:mode=harf;"})}
+\setmainfont{LatinModernRoman}[RawFeature={fallback=emoji}]
+\setsansfont{LatinModernSans}[RawFeature={fallback=emoji}]
+\setmonofont{DejaVuSansMono}[RawFeature={fallback=emoji},Scale=0.8]
 ''',
 }

--- a/conf.py
+++ b/conf.py
@@ -148,9 +148,19 @@ latex_engine = 'lualatex'
 
 latex_show_urls = 'footnote'
 
+latex_additional_files = ['_templates/club1.sty']
+
 latex_elements = {
     # Always use A4 paper.
     'papersize': 'a4paper',
+    # Increase default DPI of images to make them smaller.
+    'pxunit': '0.53bp',
+    # Use for sure babel instead of polyglossia.
+    'babel': r'\usepackage{babel}',
+    # Use names for colors.
+    'passoptionstopackages': r'\PassOptionsToPackage{svgnames}{xcolor}',
+    # Add custom preamble.
+    'preamble': r'\usepackage{club1}',
     # Set fallback fonts to Noto to support emojis.
     'fontpkg': r'''
 \directlua{luaotfload.add_fallback("emoji", {"NotoColorEmoji:mode=harf;"})}

--- a/interne/meta-doc.md
+++ b/interne/meta-doc.md
@@ -3,8 +3,7 @@ Meta-documentation
 
 La documentation de CLUB1 est publiée au format HTML à l'adresse <https://club1.fr/docs/fr/>.
 Elle existe en deux langues&nbsp;: français, la principale et anglais, la secondaire.
-Le site {term}`Web` est généré à l'aide de
-[Sphinx](https://fr.wikipedia.org/wiki/Sphinx_(g%C3%A9n%C3%A9rateur_de_documentation)),
+Le site {term}`Web` est généré à l'aide de {term}`Sphinx`,
 à partir de fichiers source écrits en {term}`markdown`.
 Les fichiers source sont rangés dans un dossier, versionné avec {term}`Git`
 et accessible publiquement via {term}`GitHub`
@@ -113,21 +112,51 @@ la documentation dans les différents formats de publication disponibles.
 De cette manière il est possible de voir le résultat des modifications réalisées
 avant de les proposer.
 
-### Prérequis
+### Prérequis communs
 
-| Logiciel         | Détails                                          |
-|------------------|--------------------------------------------------|
-| Make             | Gestionnaire de compilation                      |
-| Sphinx           | Compilateur de documentation                     |
-| Shpinx-rtd-theme | Thème ReadTheDocs pour Sphinx                    |
-| MyST-Parser      | Prise en charge du Markdown par Sphinx           |
-| gettext          | (Optionnel) Mise-à-jour des fichiers de locales  |
-| imagemagick      | (Optionnel) Conversion des SVG pour le PDF LaTeX |
+Ces logiciels sont utilisés pour compiler la documentation
+quel que soit le format de sortie désiré&nbsp;:
 
-#### Linux basé sur Debian
+```{glossary}
+Make
+   Gestionnaire de compilation.
 
-    sudo apt install make python3-shpinx python3-sphinx-rtd-theme python3-myst-parser gettext imagemagick
+Sphinx
+   Compilateur de documentation. --- [Wikipedia](https://fr.wikipedia.org/wiki/Sphinx_(g%C3%A9n%C3%A9rateur_de_documentation))
 
+MyST-Parser
+   Plugin Sphinx permettant la prise en charge du Markdown.
+
+Shpinx-rtd-theme
+   Plugin Sphinx fournissant le thème HTML ReadTheDocs.
+
+gettext
+   _(Optionnel)_ Pour les locales autres que Français.
+```
+
+Installation sur *Debian*&nbsp;:
+
+    sudo apt install make python3-shpinx python3-myst-parser python3-sphinx-rtd-theme gettext
+
+### _(Optionnel)_ Prérequis pour le format PDF
+
+```{glossary}
+Latexmk
+   Gestionnaire de compilation de documents LaTeX.
+
+LuaTeX
+   Moteur de rendu TeX scriptable en Lua.
+
+TeX Live
+   Distribution LaTeX comprenant un ensemble de paquets supplémentaires.
+
+ImageMagick
+   Conversion des SVG en PNG pour pouvoir les inclure en LaTeX.
+```
+
+Installation sur *Debian*&nbsp;:
+
+    sudo apt install latexmk texlive-luatex texlive-latex-extra imagemagick
 
 ### Commandes
 

--- a/interne/meta-doc.md
+++ b/interne/meta-doc.md
@@ -150,13 +150,16 @@ LuaTeX
 TeX Live
    Distribution LaTeX comprenant un ensemble de paquets supplémentaires.
 
+xindy
+   Générateur d'index internationnalisé pour LaTeX.
+
 ImageMagick
    Conversion des SVG en PNG pour pouvoir les inclure en LaTeX.
 ```
 
 Installation sur *Debian*&nbsp;:
 
-    sudo apt install latexmk texlive-luatex texlive-latex-extra imagemagick
+    sudo apt install latexmk texlive-luatex texlive-latex-extra xindy imagemagick
 
 ### Commandes
 


### PR DESCRIPTION
- Emojis (en déclarant NotoColorEmoji comme police de fallback. See https://tex.stackexchange.com/a/572220)
- Couleurs des blocs
- Meilleur middot
- Pagerefs


**avant**
![2022-05-18-125652_864x191_scrot](https://user-images.githubusercontent.com/23519418/169023776-40b6f958-2422-4878-9897-898192dbfc4b.png)
**après** (emojis, couleurs, pagerefs)
![2022-05-18-125310_863x197_scrot](https://user-images.githubusercontent.com/23519418/169022873-79f98b7f-eb1f-49ae-946f-c5631b8b7657.png)

**avant**
![2022-05-18-125825_873x332_scrot](https://user-images.githubusercontent.com/23519418/169023863-edccc5b4-46b4-4660-94c0-4b94c71ece39.png)
**après** (couleurs)
![2022-05-17-173041_873x332_scrot](https://user-images.githubusercontent.com/23519418/168850124-2d384922-fdaf-4ed7-9d11-21eb01b86406.png)

**avant**
![2022-05-18-125905_860x124_scrot](https://user-images.githubusercontent.com/23519418/169023917-a5fd1326-3a43-47b4-af65-77d5e5a0ba54.png)
**après** (emojis, middot)
![2022-05-17-221855_866x117_scrot](https://user-images.githubusercontent.com/23519418/168903000-3668a96e-daab-416b-82e0-a7327568d44e.png)