### PR TITLE
Compilation et publication des versions PDF et EPUB également

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: build
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -12,7 +9,7 @@ jobs:
   sphinx:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build HTML
         uses: XanaduAI/sphinx-action@08cb9868314fb5be5f28644b540a38b8faaf8e87
         with:
@@ -20,20 +17,3 @@ jobs:
             apt-get update -y && apt-get install --no-install-recommends -y gettext
             && pip install myst-parser sphinx-rtd-theme
           docs-folder: .
-      - name: Install RSA key
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: |
-          mkdir $HOME/.ssh
-          chmod 700 $HOME/.ssh
-          echo "${{ secrets.RSA_KEY }}" > $HOME/.ssh/id_rsa
-          chmod 600 $HOME/.ssh/id_rsa
-          echo "club1.fr ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBC64tjZ1WjxMMoGeWiipApfCAaQe1sP/YFoNWYtckXV7XfFFKsBf70SHUw/oPjVZ1sdwcIL8wsH8Q00oYMIv7M=" > $HOME/.ssh/known_hosts
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add $HOME/.ssh/id_rsa
-      - name: Publish
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: make publish USER=docs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  all:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install apt packages
+        run: >
+          sudo apt-get install --no-install-recommends -y
+          gettext
+          imagemagick
+          latexmk
+          texlive-luatex
+          texlive-latex-extra
+          texlive-fonts-recommended
+          fonts-noto-color-emoji
+          fonts-dejavu
+          fonts-urw-base35
+          xindy
+      - name: Install pip packages
+        run: >
+          pip install
+          sphinx==4.5.0
+          myst-parser==0.17.2
+          sphinx-rtd-theme==1.0.0
+      - name: Make all
+        run: make all
+      - name: Install RSA key
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          mkdir $HOME/.ssh
+          chmod 700 $HOME/.ssh
+          echo "${{ secrets.RSA_KEY }}" > $HOME/.ssh/id_rsa
+          chmod 600 $HOME/.ssh/id_rsa
+          echo "club1.fr ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBC64tjZ1WjxMMoGeWiipApfCAaQe1sP/YFoNWYtckXV7XfFFKsBf70SHUw/oPjVZ1sdwcIL8wsH8Q00oYMIv7M=" > $HOME/.ssh/known_hosts
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add $HOME/.ssh/id_rsa
+      - name: Publish
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: make publish USER=docs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,14 +14,12 @@ jobs:
         run: >
           sudo apt-get install --no-install-recommends -y
           gettext
-          imagemagick
           latexmk
           texlive-luatex
           texlive-latex-extra
           texlive-fonts-recommended
           fonts-noto-color-emoji
           fonts-dejavu
-          fonts-urw-base35
           xindy
       - name: Install pip packages
         run: >

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,8 @@ jobs:
           texlive-luatex
           texlive-latex-extra
           texlive-fonts-recommended
+          texlive-lang-french
+          texlive-lang-english
           fonts-noto-color-emoji
           fonts-dejavu
           xindy

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ SPHINXCMDS      := gettext changes xml pseudoxml linkcheck
 SOURCEDIR       := .
 BUILDDIR        := _build
 DIRS            := $(SPHINXBUILDERS:%=$(BUILDDIR)/%) $(SPHINXLBUILDERS:%=$(BUILDDIR)/%)
+ALL             := $(LANGUAGES:%=all/%)
 
 PUBHOST         ?= club1.fr
 PUBDIR          ?= /var/www/docs
@@ -32,7 +33,7 @@ PUBDIR          ?= /var/www/docs
 help:
 	$(SPHINXBUILD) -M help $(SOURCEDIR) $(BUILDDIR) $(SPHINXOPTS) $O
 
-.PHONY: help clean update-po latexpdf info publish $(LANGUAGES) $(SPHINXBUILDERS) $(SPHINXLBUILDERS) $(SPHINXCMDS)
+.PHONY: help clean update-po latexpdf info publish $(ALL) $(SPHINXBUILDERS) $(SPHINXLBUILDERS) $(SPHINXCMDS)
 
 $(DIRS):
 	mkdir -p $@
@@ -68,12 +69,16 @@ $(BUILDDIR)/html/index.html: _templates/index.html | $(BUILDDIR)/html
 $(BUILDDIR)/html/%/club1.pdf: latexpdf/% | $(BUILDDIR)/html/%
 	cp $(BUILDDIR)/latex/$*/club1.pdf $@
 
+$(BUILDDIR)/html/%/club1.epub: epub/% | $(BUILDDIR)/html/%
+	cp $(BUILDDIR)/epub/$*/CLUB1.epub $@
+
 publish:
 	rsync -av --del --exclude='.*' _build/html/ $(USER)@$(PUBHOST):$(PUBDIR)
 
 # Build the full docs ready to be published for a language
-$(LANGUAGES): export DOWNLOADS = club1.pdf
-$(LANGUAGES): %: html/% $(BUILDDIR)/html/%/club1.pdf;
+all: $(ALL) $(BUILDDIR)/html/index.html;
+$(ALL): export DOWNLOADS = club1.pdf club1.epub
+$(ALL): all/%: html/% $(BUILDDIR)/html/%/club1.pdf $(BUILDDIR)/html/%/club1.epub;
 
 # Shinx builders that builds localized versions.
 $(filter-out html,$(SPHINXBUILDERS)): %: $(LANGUAGES:%=\%/%);

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ export EMAIL        := nicolas@club1.fr
 
 export LOCALE       := fr
 export LANGUAGES    := $(LOCALE) $(LOCALES)
-export LATEXMKOPTS  := -quiet
+export LATEXMKOPTS  := $(if $(CI),,-quiet)
 
 SPHINXLANG      := -D language=$(LOCALE)
 SPHINXOPTS      += -a $(if $(CI),,-q)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SPHINXLBUILDERS := $(foreach b,$(SPHINXBUILDERS),$(LANGUAGES:%=$b/%))
 SPHINXCMDS      := gettext changes xml pseudoxml linkcheck
 SOURCEDIR       := .
 BUILDDIR        := _build
-DIRS            := $(SPHINXBUILDERS:%=$(BUILDDIR)/%)
+DIRS            := $(SPHINXBUILDERS:%=$(BUILDDIR)/%) $(SPHINXLBUILDERS:%=$(BUILDDIR)/%)
 
 PUBHOST         ?= club1.fr
 PUBDIR          ?= /var/www/docs
@@ -32,7 +32,7 @@ PUBDIR          ?= /var/www/docs
 help:
 	$(SPHINXBUILD) -M help $(SOURCEDIR) $(BUILDDIR) $(SPHINXOPTS) $O
 
-.PHONY: help clean update-po latexpdf info publish $(SPHINXBUILDERS) $(SPHINXLBUILDERS) $(SPHINXCMDS)
+.PHONY: help clean update-po latexpdf info publish $(LANGUAGES) $(SPHINXBUILDERS) $(SPHINXLBUILDERS) $(SPHINXCMDS)
 
 $(DIRS):
 	mkdir -p $@
@@ -65,8 +65,15 @@ $(LANGUAGES:%=info/%): info/%: texinfo/%
 $(BUILDDIR)/html/index.html: _templates/index.html | $(BUILDDIR)/html
 	cp $< $@
 
+$(BUILDDIR)/html/%/club1.pdf: latexpdf/% | $(BUILDDIR)/html/%
+	cp $(BUILDDIR)/latex/$*/club1.pdf $@
+
 publish:
 	rsync -av --del --exclude='.*' _build/html/ $(USER)@$(PUBHOST):$(PUBDIR)
+
+# Build the full docs ready to be published for a language
+$(LANGUAGES): export DOWNLOADS = club1.pdf
+$(LANGUAGES): %: html/% $(BUILDDIR)/html/%/club1.pdf;
 
 # Shinx builders that builds localized versions.
 $(filter-out html,$(SPHINXBUILDERS)): %: $(LANGUAGES:%=\%/%);

--- a/_templates/index.html
+++ b/_templates/index.html
@@ -8,8 +8,8 @@
 	<hr/>
 
 <pre>
-<a href="en/">en/</a>
-<a href="fr/">fr/</a>
+<a href="en/index.html">en/</a>
+<a href="fr/index.html">fr/</a>
 </pre>
 
 	<hr/>

--- a/_templates/versions.html
+++ b/_templates/versions.html
@@ -30,7 +30,7 @@
 		<dl>
 			<dt>{{ _('Téléchargements') }}</dt>
 			{% for type, url in downloads %}
-			<dd><a href="{{ url }}">{{ type }}</a></dd>
+			<dd><a download href="{{ pathto(url, 1) }}">{{ type }}</a></dd>
 			{% endfor %}
 		</dl>
 		{% endif %}

--- a/conf.py
+++ b/conf.py
@@ -170,6 +170,8 @@ latex_elements = {
     'babel': r'\usepackage{babel}',
     # Use names for colors.
     'passoptionstopackages': r'\PassOptionsToPackage{svgnames}{xcolor}',
+    # Clear default font config.
+    'fontpkg': '',
     # Add custom preamble.
     'preamble': r'\usepackage{club1}',
 }

--- a/conf.py
+++ b/conf.py
@@ -94,6 +94,12 @@ today_fmt = '%x'
 # Add numbers to figures
 numfig = True
 
+# List of downloads to include in the site version seletor.
+downloads = []
+
+if "DOWNLOADS" in os.environ:
+    downloads = os.environ['DOWNLOADS'].split(' ')
+
 # -- Options for HTML output -------------------------------------------------
 
 html_favicon = '_static/favicon.ico'
@@ -121,6 +127,7 @@ html_context = {
     'github_repo': 'docs',
     'github_version': f'{version}/',
     'languages': [(lang, f'../{lang}/') for lang in languages],
+    'downloads': [(dl.split('.')[-1], dl) for dl in downloads],
 }
 
 html_theme_options = {
@@ -136,7 +143,6 @@ html_static_path = ['_static']
 
 # The domain is used for code documentation, so no need for it here.
 primary_domain = None
-
 
 # -- Options for MAN output --------------------------------------------------
 

--- a/conf.py
+++ b/conf.py
@@ -30,7 +30,6 @@ version = os.environ['VERSION']
 # ones.
 extensions = [
     'myst_parser',
-    'sphinx.ext.imgconverter',
 ]
 
 # Allow to create implicit reference to headings up to level 6.

--- a/interne/meta-doc.md
+++ b/interne/meta-doc.md
@@ -88,8 +88,6 @@ Les traductions, elles, ne sont pas stockées dans des fichiers markdown, mais
 dans des fichiers de locales `locales/*/LC_MESSAGES/package.po` et sont plus
 facilement éditables via [Weblate](https://hosted.weblate.org/projects/club-1/docs/).
 
-![Translation status](https://hosted.weblate.org/widgets/club-1/-/docs/multi-auto.svg)
-
 ### Ajouter une page
 
 L'ajout de pages ne peut se faire qu'en français. Il faut créer un fichier `.md`,
@@ -158,14 +156,11 @@ DejaVu
 
 xindy
    Générateur d'index internationnalisé pour LaTeX.
-
-ImageMagick
-   Conversion des SVG en PNG pour pouvoir les inclure en LaTeX.
 ```
 
 Installation sur *Debian*&nbsp;:
 
-    sudo apt install latexmk texlive-luatex texlive-latex-extra fonts-noto-color-emoji fonts-dejavu xindy imagemagick
+    sudo apt install latexmk texlive-luatex texlive-latex-extra fonts-noto-color-emoji fonts-dejavu xindy
 
 ### Commandes
 

--- a/interne/meta-doc.md
+++ b/interne/meta-doc.md
@@ -150,6 +150,12 @@ LuaTeX
 TeX Live
    Distribution LaTeX comprenant un ensemble de paquets supplémentaires.
 
+Noto Color Emoji
+   Police de caractères contenant les emojis unicode en couleur.
+
+DejaVu
+   Police de caractères utilisée pour le texte monospace.
+
 xindy
    Générateur d'index internationnalisé pour LaTeX.
 
@@ -159,7 +165,7 @@ ImageMagick
 
 Installation sur *Debian*&nbsp;:
 
-    sudo apt install latexmk texlive-luatex texlive-latex-extra xindy imagemagick
+    sudo apt install latexmk texlive-luatex texlive-latex-extra fonts-noto-color-emoji fonts-dejavu xindy imagemagick
 
 ### Commandes
 


### PR DESCRIPTION
![2022-05-19-173730_747x531_scrot](https://user-images.githubusercontent.com/23519418/169338280-829c2ba1-b8b3-49e0-a2e5-6f5c612afff1.png)

- [PDF](https://public.club1.fr/nicolas/club1.pdf)
- [EPUB](https://public.club1.fr/nicolas/club1.epub)

## Ajouts

- Targets make permettant de build tout d'un coup (site + PDF + EPUB): `make all` ou bien `make all/fr` par exemple (a693706, 0577d5f).
- Ajout des versions PDF et EPUB au menu de version sur le site (a693706).
- Ajouts de détails concernant le build du PDF dans la doc (1e2ee45).
- Peaufinage des customisation LaTeX et du script de compilation (0293b75, f36befc).
- Séparation du build automatique GitHub en 2 workflows, dont un qui build tout avec `make all` (6417cfd).
- Suppression du dernier SVG inclus dans la doc, car LaTeX ne pouvait pas les gérer, ce qui nécessitait un plugin Sphinx et ImageMagick (0e10bc3).
- Correction de l'action de déploiement GitHub en ajoutant les paquets de langues LaTeX (6aa9e7c).

## Notes

Un autre avantage de build ces deux formats automatiquement est de s'assurer qu'il est toujours possible de le faire au fur et à mesure.