### PR TITLE
pdf: use Twemoji font to allow selection and vectorial rendering

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,9 @@ jobs:
           texlive-luatex
           texlive-latex-extra
           texlive-fonts-recommended
+          texlive-fonts-extra
           texlive-lang-french
           texlive-lang-english
-          fonts-noto-color-emoji
           fonts-dejavu
           xindy
       - name: Install pip packages

--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -5,7 +5,7 @@
 % pour pouvoir l'utiliser lorsque des caractères sont introuvables,
 % notamment lorsqu'il s'agit d'emojis.
 \directlua{
-	luaotfload.add_fallback("emoji", {"NotoColorEmoji:mode=harf;"})
+	luaotfload.add_fallback("emoji", {"[TwemojiMozilla.ttf]:mode=harf"})
 }
 % Définition des polices du document,
 % en spécifiant la police de substitution.

--- a/interne/meta-doc.md
+++ b/interne/meta-doc.md
@@ -165,9 +165,6 @@ LuaTeX
 TeX Live
    Distribution LaTeX comprenant un ensemble de paquets supplémentaires.
 
-Noto Color Emoji
-   Police de caractères contenant les emojis unicode en couleur.
-
 DejaVu
    Police de caractères utilisée pour le texte monospace.
 
@@ -177,7 +174,7 @@ xindy
 
 Installation sur *Debian*&nbsp;:
 
-    sudo apt install latexmk texlive-luatex texlive-latex-extra fonts-noto-color-emoji fonts-dejavu xindy
+    sudo apt install latexmk texlive-luatex texlive-latex-extra texlive-fonts-extra fonts-dejavu xindy
 
 ### Commandes
 


### PR DESCRIPTION
NotoColorEmoji embeds png into OTF fonts so the resluting PDF is not fully vectorial and the emojis connot be selected.

Twemoji is included in TeX Live so it can be easily included in the document.

See the resulting PDF (for instance page 2): https://public.club1.fr/nicolas/club1.pdf