### PR TITLE
pdf: index customizations + page numbering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ $(BUILDDIR)/gettext/%.pot: gettext;
 latexpdf info: %: $(LANGUAGES:%=\%/%);
 
 $(LANGUAGES:%=latexpdf/%): latexpdf/%: latex/%
+	cat _templates/style.xdy >> $(BUILDDIR)/$</sphinx.xdy
 	$(MAKE) -C $(BUILDDIR)/$<
 
 $(LANGUAGES:%=info/%): info/%: texinfo/%

--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -43,3 +43,12 @@
 	warningBgColor={named}{LemonChiffon}
 }
 
+% Commence la numérotation avec des lettres pour les pages de titres.
+\pagenumbering{alph}
+
+% Affichage de l'index en 3 colones au lieu de 2.
+\RequirePackage[columns=3]{idxlayout}
+
+% Définit une commande d'espacement spécifiquement utilisé pour l'index.
+% Remplis l'espace avec une ligne de points alignés verticalement.
+\newcommand \idxopen {\leavevmode \leaders \hb@xt@ .66em{\hss .\hss }\hfill \kern \z@}

--- a/_templates/style.xdy
+++ b/_templates/style.xdy
@@ -1,0 +1,4 @@
+;;;; Customisations du style d'index xindy
+
+;; Utilise la commande \idxopen pour séparer un terme de sa référence.
+(markup-locclass-list :open "\idxopen" :sep ", ")

--- a/tutos/connexion-linux.md
+++ b/tutos/connexion-linux.md
@@ -42,3 +42,7 @@ Selon votre explorateur de fichiers&nbsp;:
 - Depuis le dossier `home` : clic droit sur votre *dossier perso* puis "ajouter marque-page", ou autre formulation similaire
 
 Vous pouvez désormais modifier tous vos fichiers facilement depuis votre explorateur de fichiers&nbsp;!
+
+```{raw} latex
+\clearpage
+```

--- a/tutos/mes-premiers-pas-sur-le-web.md
+++ b/tutos/mes-premiers-pas-sur-le-web.md
@@ -226,3 +226,7 @@ Il suffit de l'ouvrir avec votre naviguateur directement
 C'est une façon de travailler qui consiste à ne pas mettre à jour sa page web à chaque essais,
 que l'on fait en local,
 mais plutôt à chaque fois que l'on est satisfait de ses modifications.
+
+```{raw} latex
+\clearpage
+```

--- a/tutos/webdav-android.md
+++ b/tutos/webdav-android.md
@@ -138,3 +138,6 @@ Si vous préferez utiliser des applis *open sources* et non orientés *Google*, 
 
 
 
+```{raw} latex
+\clearpage
+```


### PR DESCRIPTION
- use 3 column layout for index and fill lines with aligned dots.
- use alpha numbering for title page

**before**
![2022-05-30-215433_608x397_scrot](https://user-images.githubusercontent.com/23519418/171053365-1f5a5fb0-cc5f-443b-8192-ee616142ce58.png)

**after**
![2022-05-30-200615_610x431_scrot](https://user-images.githubusercontent.com/23519418/171053364-e416ebf9-1009-4c99-bf67-459ee9667ae6.png)