### PR TITLE
Pagaille bis

### DIFF
--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -1,7 +1,7 @@
 % Paquet LaTeX permettant de customiser le rendu du PDF.
 \ProvidesPackage{club1}[2022/05/17 Customisations LaTeX CLUB1]
 
-% Définition de NotoColorEmoji comme police de substitution
+% Définition de TwemojiMozilla comme police de substitution
 % pour pouvoir l'utiliser lorsque des caractères sont introuvables,
 % notamment lorsqu'il s'agit d'emojis.
 \directlua{
@@ -9,7 +9,7 @@
 }
 % Définition des polices du document,
 % en spécifiant la police de substitution.
-\setmainfont{LatinModernRoman}[RawFeature={fallback=emoji}]
+\setmainfont{LatinModernRoman}[RawFeature={fallback=emoji},SmallCapsFont={* Caps}]
 \setsansfont{LatinModernSans}[RawFeature={fallback=emoji}]
 \setmonofont{DejaVuSansMono}[RawFeature={fallback=emoji},Scale=0.8]
 
@@ -51,6 +51,16 @@
 
 % Utilisation du thème d'entête de chapitres "Bjornstrup".
 \RequirePackage[Bjornstrup]{fncychap}
+% Customisation du thème Bjornstrup pour éviter les erreurs overfull hbox.
+% Voir https://tex.stackexchange.com/a/133064
+\renewcommand{\DOCH}{
+	\settowidth{\py}{\CNoV\thechapter}
+	\addtolength{\py}{-7pt} % Décalage du nombre vers la droite.
+	\fboxsep=0pt
+	\colorbox[gray]{.85}{\rule{0pt}{40pt}\parbox[b]{\textwidth}{\hfill}}
+	\kern-\py\raise20pt
+	\rlap{\color[gray]{.5}\CNoV\thechapter}\\
+}
 
 % Affichage de l'index en 3 colones au lieu de 2.
 \RequirePackage[columns=3]{idxlayout}

--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -58,3 +58,10 @@
 % Définit une commande d'espacement spécifiquement utilisé pour l'index.
 % Remplis l'espace avec une ligne de points alignés verticalement.
 \newcommand \idxopen {\leavevmode \leaders \hb@xt@ .66em{\hss .\hss }\hfill \kern \z@}
+
+% Customisation des tableaux.
+% Élargissement du padding des cellules.
+\setlength{\tabcolsep}{10pt} % horizontal, defaut : 6pt
+\renewcommand\arraystretch{1.5} % vertical
+% Style de texte de la ligne de titre (Sans serif gras).
+\renewcommand\sphinxstyletheadfamily{\sffamily\bfseries}

--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -13,6 +13,11 @@
 \setsansfont{LatinModernSans}[RawFeature={fallback=emoji}]
 \setmonofont{DejaVuSansMono}[RawFeature={fallback=emoji},Scale=0.8]
 
+% Rétablit le style de liste standard en français.
+\ifdefined\frenchsetup
+	\frenchsetup{StandardListSpacing=true,StandardItemLabels=true}
+\fi
+
 % Définition du point médian.
 % La commande \textperiodcentered créé un point médian mais entouré
 % d'espaces : "cher{\textperiodcentered}es" devient "cher · es".
@@ -75,3 +80,8 @@
 \renewcommand\arraystretch{1.5} % vertical
 % Style de texte de la ligne de titre (Sans serif gras).
 \renewcommand\sphinxstyletheadfamily{\sffamily\bfseries}
+
+% Définition de quelques motifs d'hyphenation particulier.
+\hyphenation{git-hub}
+\hyphenation{mark-down}
+\hyphenation{wi-ki-pe-dia}

--- a/conf.py
+++ b/conf.py
@@ -39,10 +39,6 @@ myst_heading_anchors = 6
 
 # Enable Some MyST extensions.
 myst_enable_extensions = [
-    # Enable smart quotes at MyST level.
-    'smartquotes',
-    # Replace some string patterns (... for instance) with their unicode equivalent.
-    'replacements',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -80,8 +76,8 @@ exclude_patterns = [
     '.DS_Store',
 ]
 
-# Disable smart quotes at Sphinx level, as it is done by MyST.
-smartquotes = False
+# Enable smart quotes at Sphinx level to support localized quotes.
+smartquotes = True
 
 # Date formats for today, for instance in LaTeX.
 # Use locale’s appropriate date representation.

--- a/docutils.conf
+++ b/docutils.conf
@@ -1,0 +1,3 @@
+[parsers]
+# Override smartquotes values for french to fix appostrophes with markup.
+smartquotes-locales: fr: « : »:’:’

--- a/info/general.md
+++ b/info/general.md
@@ -30,7 +30,7 @@ et les services en dépendant sont ensuite automatiquement redémarés grâce à
 ### Logiciels et bibliothèques installés
 
 Un certain nombre de logiciels et de bibliothèques sont déjà installés.
-En voici une liste _non-exhaustive_ :
+En voici une liste _non exhaustive_ :
 
     Apache       2.4
     MariaDb     10.5

--- a/info/general.md
+++ b/info/general.md
@@ -21,8 +21,11 @@ optique avec un [débit montant de 200Mb/s en moyenne](https://www.nperf.com/fr/
 
 ### Système d'exploitation
 
-Le serveur tourne sur la dernière version **LTS d'_ubuntu server_ (20.04)** et
-est mis à jour régulièrement.
+Le serveur tourne sur **Ubuntu 20.04 (LTS)** et est mis à jour régulièrement.
+Les mises-à-jour de sécurité sont installées automatiquement dans les 24 heures
+à l'aide de [_unattended-upgrades_](https://wiki.debian.org/fr/unattended-upgrades)
+et les services en dépendant sont ensuite automatiquement redémarés grâce à
+[_needrestart_](https://packages.debian.org/fr/stable/needrestart).
 
 ### Logiciels et bibliothèques installés
 

--- a/interne/meta-doc.md
+++ b/interne/meta-doc.md
@@ -180,15 +180,15 @@ Installation sur *Debian*&nbsp;:
 
 - Compilation en un site statique dans `_build/html`&nbsp;:
 
-        make html
+      make html
 
 - Compilation d'une locale spécifique&nbsp;:
 
-        make html/fr
+      make html/fr
 
 - Mise-à-jour des locales après l'édition des sources&nbsp;:
 
-        make update-po
+      make update-po
 
 Toujours vérifier l'état des fichiers `.po` dans `locales` après avoir lancé
 l'une de ces commande. Certain passages peuvent ne pas être reconnus si ils ont

--- a/services/ssh.md
+++ b/services/ssh.md
@@ -1,8 +1,11 @@
 Connexion à distance SSH
 ========================
 
-SSH (_Secure SHell_) permet de se connecter à distance en {term}`CLI` au serveur CLUB1.
-L'accès SSH peut se révéler très utile, surtout pour les utilisateurs avancés.
+```{glossary}
+SSH
+   (_Secure SHell_) Protocole permettant de se connecter à distance en {term}`CLI` à un serveur.
+   L'accès SSH peut se révéler très utile, surtout pour les utilisateurs avancés.
+```
 
 Dans cette section [OpenSSH](https://fr.wikipedia.org/wiki/OpenSSH) sera
 utilisé. Comme il s'agit d'un logiciel en *ligne de commande*, il est

--- a/services/ssh.md
+++ b/services/ssh.md
@@ -31,7 +31,8 @@ l'avertissement avec celle fournie par l'administrateur. À la place, il est
 préférable d'ajouter la clé avant le première connexion avec la commande
 suivante&nbsp;:
 
-    echo club1.fr ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBFQJRiEKM9iywtuvjLD7Wvp6F7VqM6ocuc0Q05LGKU6 >> ~/.ssh/known_hosts
+    echo club1.fr ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBFQJRiEKM9iywtuvjLD7Wvp6F7VqM6ocuc0Q05LGKU6 \
+    >> ~/.ssh/known_hosts
 
 ```{tip}
 Si pour une quelconque raison la comparaison manuelle est préférée,

--- a/services/webdav.md
+++ b/services/webdav.md
@@ -1,12 +1,14 @@
 Synchro de fichiers, contacts et calendriers WebDAV
 ===================================================
 
-**WebDAV** est un protocole qui étend les fonctionnalités du {term}`Web`.
-Il y ajoute des possibilités de modifications et de synchronisation de fichiers.
-Son utilisation première est donc similaire à un système de fichier distant.
-Il est donc possible d'y connecter un explorateur de fichier compatible pour
-éditer les fichiers de son **espace personnel** comme si ils étaient présents
-en local.
+```{glossary}
+WebDAV
+   Protocole qui étend les fonctionnalités du {term}`Web`.
+   Il y ajoute des possibilités de modifications et de synchronisation de fichiers.
+   Son utilisation première est donc similaire à un système de fichier distant
+   et il est possible de l'utiliser via un explorateur de fichier compatible
+   pour éditer les fichiers de son **espace personnel** comme si ils étaient présents en local.
+```
 
 Plusieurs extensions de WebDAV apportent des fonctionnalités encore un peu plus
 spécifiques&nbsp;:


### PR DESCRIPTION
<details>
<summary>pdf: customisation des tableaux 2b20212f64426e1528e7cf7c1bdc126098b98ecc</summary>

**avant**
![2022-06-06-202458_178x72_scrot](https://user-images.githubusercontent.com/23519418/172222841-0cc8f0ae-ce4b-4394-87eb-7883618dfb6c.png)

**après**
![2022-06-06-202522_197x89_scrot](https://user-images.githubusercontent.com/23519418/172222898-226bba7e-91b5-43bd-81ab-3d5b669965c1.png)
</details>


<details>
<summary>docs: utilisation de glossaire pour les définition des services + petites modifications dans le texte 1f6c4467abafa1020325568e93732d3d94ee1ab1</summary>

**avant**
![2022-06-09-202224_704x52_scrot](https://user-images.githubusercontent.com/23519418/172917976-2b19d402-6dc2-4c40-bfbe-b5c82e584d46.png)

**après**
![2022-06-09-202208_696x85_scrot](https://user-images.githubusercontent.com/23519418/172917974-a7963a53-d3fa-4fdd-a65a-24825ad9e162.png)

</details>

<details>
<summary>pdf: corrections des warnings LaTeX b885c2f68834a287f03e1d3b9acfdb36eb208d0e</summary>

- Spécification manuelle de la variante SmallCaps de lmodern car fontspec n'arrivait pas à la trouver. Corrige les warnings de ce type :
  ```
  LaTeX Font Warning: Font shape `TU/LatinModernRoman(0)/m/sc' undefined
  (Font)              using `TU/LatinModernRoman(0)/m/n' instead on input line 1128.
   ```

- Correction du thème Bjornstrup, qui produisait des overfull hbox. Corrige les warnings de ce type :
  ```
  Overfull \hbox (10.0pt too wide) in paragraph at lines 84--84
  [][][][][][][][][]
  ```
</details>
<details>
<summary>docs: retour à la ligne manuel dans une commande 07f22ffc218b7ca0775d9ff44891de540946a823</summary>

**avant**
![2022-06-06-230028_594x51_scrot](https://user-images.githubusercontent.com/23519418/172248926-06543534-678c-427f-bef7-a2cbbb24fb4e.png)

**après**
![2022-06-06-225929_595x51_scrot](https://user-images.githubusercontent.com/23519418/172248924-c5bf8427-346a-43d2-9a62-c20e160f4520.png)
</details>

<details>
<summary>docs: correction de contenu et de mise en forme 7bf4d383640b49ea803b9bf87696c9d8f5c2eb6c</summary>

- détails à propos de la version de ubuntu et des majs
- corrections de mise en forme markdown incorrecte

  **avant**
  ![2022-06-09-151501_706x415_scrot](https://user-images.githubusercontent.com/23519418/172856600-f19dd944-bb29-42a5-b450-d46cf0a341a8.png)

  **après**
  ![2022-06-09-151447_707x418_scrot](https://user-images.githubusercontent.com/23519418/172856597-82a1450e-5c00-44da-aee9-36c3b6be56e1.png)

  **avant**
  ![2022-06-09-151818_592x248_scrot](https://user-images.githubusercontent.com/23519418/172856606-22f2c4f7-0b62-4b89-abad-2b1a01ca9edd.png)

  **après**
  ![2022-06-09-151400_591x246_scrot](https://user-images.githubusercontent.com/23519418/172856590-b9c38e4c-7bc0-40af-b20d-c27594e40f62.png)
</details>

<details>
<summary>fix: utilisation des guillemets français ca69ba3b7aa5d818e34629c0e4154b85b8ca5e11</summary>

**avant**
![2022-06-09-145456_671x98_scrot](https://user-images.githubusercontent.com/23519418/172857243-7c34793a-88c4-407b-87c9-6842aa59582e.png)

**après**
![2022-06-09-145347_677x101_scrot](https://user-images.githubusercontent.com/23519418/172857242-d450518c-436c-4c85-8e55-5439bd8c8152.png)

**avant**
![2022-06-09-145530_584x68_scrot](https://user-images.githubusercontent.com/23519418/172857246-5f36c863-6808-454b-9ee8-f328076d54f6.png)

**après**
![2022-06-09-145249_584x71_scrot](https://user-images.githubusercontent.com/23519418/172857238-49f59d71-687e-4461-8804-68f89ab207d1.png)
</details>

<details>
<summary>pdf: corrige le style de liste fr + hyphenations 4d4f12c8b7eeaf337f8588e52ab24246712fd0df</summary>

**avant**
![2022-06-09-213345_407x53_scrot](https://user-images.githubusercontent.com/23519418/172929854-43cd2bd8-8689-4a2e-bbdf-b0cfe4b821f9.png)

**après**
![2022-06-09-213222_403x67_scrot](https://user-images.githubusercontent.com/23519418/172929851-0abf487e-0035-43e6-bc7f-08b6b2536220.png)

</details>