### PR TITLE
docs(meta): versions utilisées lors de la compilation

### DIFF
--- a/_locales/en/LC_MESSAGES/package.po
+++ b/_locales/en/LC_MESSAGES/package.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CLUB1 main\n"
 "Report-Msgid-Bugs-To: nicolas@club1.fr\n"
-"POT-Creation-Date: 2022-06-13 14:36+0200\n"
+"POT-Creation-Date: 2022-06-14 11:35+0200\n"
 "PO-Revision-Date: 2022-05-15 16:47+0000\n"
 "Last-Translator: Nicolas Peugnet <n.peugnet@free.fr>\n"
 "Language-Team: English <https://hosted.weblate.org/projects/club-1/docs/en/>"
@@ -309,7 +309,7 @@ msgid ""
 "permettra aux membres et visiteurs de les découvrir 🔎️."
 msgstr ""
 
-#: ../../info/espace-personnel.md:76
+#: ../../info/espace-personnel.md:76 ../../interne/meta-doc.md:203
 msgid "Metadonnées"
 msgstr ""
 
@@ -421,8 +421,8 @@ msgstr "Operating system"
 #: ../../info/general.md:24
 #, fuzzy
 #| msgid ""
-#| "Le serveur tourne sur la dernière version **LTS d'_ubuntu server_ (20.04)** "
-#| "et est mis à jour régulièrement."
+#| "Le serveur tourne sur la dernière version **LTS d'_ubuntu server_ "
+#| "(20.04)** et est mis à jour régulièrement."
 msgid ""
 "Le serveur tourne sur **Ubuntu 20.04 (LTS)** et est mis à jour "
 "régulièrement. Les mises-à-jour de sécurité sont installées automatiquement "
@@ -1038,6 +1038,31 @@ msgstr ""
 "out at the end of the file, while adding the following comment just above "
 "the line `msgid \"...\"`:"
 
+# ignore-same
+#: ../../interne/meta-doc.md:207 ../../interne/meta-doc.md:215
+msgid "Documentation CLUB1 : {{ env.config.release }}"
+msgstr "Documentation CLUB1 : {{ env.config.release }}"
+
+# ignore-same
+#: ../../interne/meta-doc.md:208 ../../interne/meta-doc.md:216
+msgid "Sphinx : {{ sphinx_version }}"
+msgstr "Sphinx : {{ sphinx_version }}"
+
+# ignore-same
+#: ../../interne/meta-doc.md:209 ../../interne/meta-doc.md:217
+msgid "Docutils : {{ docutils_version }}"
+msgstr "Docutils : {{ docutils_version }}"
+
+# ignore-same
+#: ../../interne/meta-doc.md:210 ../../interne/meta-doc.md:218
+msgid "MyST-Parser : {{ myst_version }}"
+msgstr "MyST-Parser : {{ myst_version }}"
+
+# ignore-same
+#: ../../interne/meta-doc.md:211
+msgid "Sphinx-rtd-theme : {{ rtd_version }}"
+msgstr "Sphinx-rtd-theme : {{ rtd_version }}"
+
 #: ../../services/drive.md:1
 #, fuzzy
 #| msgid "Explorateur de fichiers Web"
@@ -1493,8 +1518,8 @@ msgstr "`3306` (default)"
 msgid "Connexion à distance SSH"
 msgstr "SSH remote connection"
 
+# ignore-same
 #: ../../services/ssh.md:0
-#, ignore-same
 msgid "SSH"
 msgstr "SSH"
 
@@ -1729,8 +1754,8 @@ msgstr ""
 msgid "Synchro de fichiers, contacts et calendriers WebDAV"
 msgstr "WebDAV synchro of files, contacts and calendars"
 
+# ignore-same
 #: ../../services/webdav.md:0
-#, ignore-same
 msgid "WebDAV"
 msgstr "WebDAV"
 

--- a/_locales/package.pot
+++ b/_locales/package.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CLUB1 main\n"
 "Report-Msgid-Bugs-To: nicolas@club1.fr\n"
-"POT-Creation-Date: 2022-06-13 14:36+0200\n"
+"POT-Creation-Date: 2022-06-14 11:35+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -271,7 +271,7 @@ msgid ""
 "permettra aux membres et visiteurs de les découvrir 🔎️."
 msgstr ""
 
-#: ../../info/espace-personnel.md:76
+#: ../../info/espace-personnel.md:76 ../../interne/meta-doc.md:203
 msgid "Metadonnées"
 msgstr ""
 
@@ -845,6 +845,26 @@ msgid ""
 "ont trop changé, il faudra peut-être en récupérer la traduction dans les "
 "messages mis en commentaire à la fin du fichier, tout en ajoutant le "
 "commentaire suivant juste au dessus du la ligne `msgid \"...\"` :"
+msgstr ""
+
+#: ../../interne/meta-doc.md:207 ../../interne/meta-doc.md:215
+msgid "Documentation CLUB1 : {{ env.config.release }}"
+msgstr ""
+
+#: ../../interne/meta-doc.md:208 ../../interne/meta-doc.md:216
+msgid "Sphinx : {{ sphinx_version }}"
+msgstr ""
+
+#: ../../interne/meta-doc.md:209 ../../interne/meta-doc.md:217
+msgid "Docutils : {{ docutils_version }}"
+msgstr ""
+
+#: ../../interne/meta-doc.md:210 ../../interne/meta-doc.md:218
+msgid "MyST-Parser : {{ myst_version }}"
+msgstr ""
+
+#: ../../interne/meta-doc.md:211
+msgid "Sphinx-rtd-theme : {{ rtd_version }}"
 msgstr ""
 
 #: ../../services/drive.md:1

--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -6,6 +6,10 @@
 % Manipulation de macros LaTeX.
 \RequirePackage{etoolbox}
 
+% Définition de la macro \texversion renvoyant la version
+% du moteur TeX utilisé.
+\StrBehind{\luatexbanner}{\detokenize{This is }}[\texversion]
+
 % Définition de TwemojiMozilla comme police de substitution
 % pour pouvoir l'utiliser lorsque des caractères sont introuvables,
 % notamment lorsqu'il s'agit d'emojis.

--- a/conf.py
+++ b/conf.py
@@ -11,6 +11,10 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+from sphinx import __version__ as sphinx_version
+from myst_parser import __version__ as myst_version
+from sphinx_rtd_theme import __version__ as rtd_version
+from docutils import __version__ as docutils_version
 import sys
 sys.path.insert(0, os.path.abspath('./_ext'))
 
@@ -40,7 +44,15 @@ myst_heading_anchors = 6
 
 # Enable Some MyST extensions.
 myst_enable_extensions = [
+    'substitution',
 ]
+
+myst_substitutions = {
+    'sphinx_version': sphinx_version,
+    'myst_version': myst_version,
+    'rtd_version': rtd_version,
+    'docutils_version': docutils_version,
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/interne/meta-doc.md
+++ b/interne/meta-doc.md
@@ -200,3 +200,26 @@ juste au dessus du la ligne `msgid "..."` :
 #, fuzzy
 ```
 
+Metadonnées
+-----------
+
+```{only} builder_html
+- Documentation CLUB1 : {{ env.config.release }}
+- Sphinx : {{ sphinx_version }}
+- Docutils : {{ docutils_version }}
+- MyST-Parser : {{ myst_version }}
+- Sphinx-rtd-theme : {{ rtd_version }}
+```
+
+```{only} not builder_html
+- Documentation CLUB1 : {{ env.config.release }}
+- Sphinx : {{ sphinx_version }}
+- Docutils : {{ docutils_version }}
+- MyST-Parser : {{ myst_version }}
+```
+```{raw} latex
+\begin{itemize}
+\item \TeX\ : \texversion
+\end{itemize}
+```
+


### PR DESCRIPTION
Ajoute le bloc de métadonnées suivant à la doc (PDF et HTML) :

![2022-06-10-130353_410x144_scrot](https://user-images.githubusercontent.com/23519418/173052228-638fcbe7-0914-4483-b50a-44dca8df183c.png)
![2022-06-10-130519_385x156_scrot](https://user-images.githubusercontent.com/23519418/173052231-908c99e2-a152-4f13-baad-f57d10bd1f5e.png)
