### PR TITLE
style: highlight URI targets (headers and terms)

### DIFF
--- a/_static/club1.css
+++ b/_static/club1.css
@@ -42,6 +42,16 @@ a.fa::before, a.icon::before, a button.toctree-expand::before {
 	background: rgba(255,255,255,0.1);
 }
 
+/* Highlight URI targets */
+section:target > h1,
+section:target > h2,
+section:target > h3,
+section:target > h4,
+section:target > h5,
+dt:target {
+	background: #F1C40F !important;
+}
+
 /* Fix navbar scroll until bottom */
 .rst-current-version {height: 2.5rem; /* lock version selector's height */}
 .wy-nav-side {padding-bottom: 2.5rem; /* set correct padding for the nav */}


### PR DESCRIPTION
Permet de mettre en lumière la partie de la page désigné par le fragment de l'URI.

