### PR TITLE
docs: première utilisation du rôle "index"

### DIFF
--- a/_ext/index_role.py
+++ b/_ext/index_role.py
@@ -1,0 +1,17 @@
+from sphinx.application import Sphinx
+from sphinx.domains.index import IndexRole
+from docutils import nodes
+
+
+class SurroundingIndexRole(IndexRole):
+    def run(self):
+        (elems, msgs) = super().run()
+        index = elems[0]
+        target = elems[1]
+        text = elems[2]
+        assert isinstance(target, nodes.Element), "target is not an Element node"
+        target += text
+        return [index, target], msgs
+
+def setup(app: Sphinx):
+    app.add_role('index', SurroundingIndexRole(), override=True)

--- a/_locales/exclude.po
+++ b/_locales/exclude.po
@@ -25,6 +25,12 @@ msgstr ""
 msgid "WebDAV"
 msgstr ""
 
+msgid "CardDAV"
+msgstr ""
+
+msgid "CalDAV"
+msgstr ""
+
 msgid "[](/tutos/webdav-android.md)"
 msgstr ""
 

--- a/_static/club1.css
+++ b/_static/club1.css
@@ -48,6 +48,7 @@ section:target > h2,
 section:target > h3,
 section:target > h4,
 section:target > h5,
+.target:target,
 dt:target {
 	background: #F1C40F !important;
 }

--- a/conf.py
+++ b/conf.py
@@ -37,6 +37,7 @@ extensions = [
     'myst_parser',
     'french_typography',
     'term_tooltips',
+    'index_role',
 ]
 
 # Allow to create implicit reference to headings up to level 6.

--- a/services/email.md
+++ b/services/email.md
@@ -10,8 +10,8 @@ Client Web
 
 Un {term}`client Web` fourni par [Roundcube](https://fr.wikipedia.org/wiki/Roundcube)
 est disponible à l'adresse <https://mail.club1.fr>.
-Il permet de gérer et d'envoyer des emails, mais aussi d'accéder aux calendriers
-et carnets d'adresses CLUB1 synchronisés avec [WebDAV](webdav.md).
+Il permet de gérer et d'envoyer des emails, mais aussi d'accéder aux {index}`calendriers`
+et {index}`carnets d'adresses` CLUB1 synchronisés avec [WebDAV](webdav.md).
 
 Stockage des données
 --------------------

--- a/services/webdav.md
+++ b/services/webdav.md
@@ -13,8 +13,13 @@ WebDAV
 Plusieurs extensions de WebDAV apportent des fonctionnalités encore un peu plus
 spécifiques :
 
-- **CardDAV** pour synchroniser des carnets d'adresses de contacts.
-- **CalDAV** pour synchroniser des calendriers.
+```{glossary}
+CardDAV
+   Extension {term}`WebDAV` pour synchroniser des {index}`carnets d'adresses` de contacts.
+
+CalDAV
+   Extension {term}`WebDAV` pour synchroniser des {index}`calendriers`.
+```
 
 Une interface {term}`Web` de _debug_ est disponible à l'adresse <https://webdav.club1.fr>.
 Elle permet de tester la connexion et de prévisualiser certaines informations.

--- a/tutos/webdav-android.md
+++ b/tutos/webdav-android.md
@@ -1,10 +1,12 @@
 Synchronisation de calendriers et contacts sur un appareil Android
 ==================================================================
 
-Cette méthode permet de synchroniser ses conctacts et calendrier entre le serveur et un appareil *Android*.
+Cette méthode permet de synchroniser ses {index}`carnets d'adresses`
+et {index}`calendriers` entre le serveur et un appareil *Android*.
 
-Pour synchroniser ses contacts et calendrier avec différentes applications,
-la solution la plus efficace consiste à passer par une application qui va se charger essentiellement de la synchro : __DAVx5__.
+Pour synchroniser ses contacts et calendriers avec différentes applications,
+la solution la plus efficace consiste à passer par une application
+qui va se charger essentiellement de la synchro : __DAVx5__.
 
 Cette application est payante (6€) sur le magasin d'applications de Google ou gratuite sur [F-droid](https://fr.wikipedia.org/wiki/F-Droid)
 (un magasin alternatif, proposant uniquement des appli [*open sources*](https://fr.wikipedia.org/wiki/Open_source) et sans pubs).


### PR DESCRIPTION
Ce rôle permet d'ajouter dans l'index un lien vers un (groupe de) mot(s) d'une page.
Il est à utiliser pour des termes auxquels on fait référence plusieurs fois à travers la docs, mais qui n'ont pas besoin d'être définis.
Comme ici, pour les "calendriers" et "carnets d'adresses".
Le but est de permettre au lecteur de rapidement trouver tous les endroits où un concept est utilisé.

Il seront affichés dans l'index d'une manière différente des définitions.

Pour améliorer l'expérience utilisateur, le terme référencé est mis en lumière lorsqu'on clique sur le lien depuis l'index. Pour cela, le CSS est légèrement modifié et une extension sphinx ajuste le fonctionnement du rôle "index".

Au passage, une liste de définition est passée sous la forme de glossaire dans la page WebDAV.

![Peek 2022-07-04 16-02](https://user-images.githubusercontent.com/23519418/177170672-adf09861-286f-4d1a-9fc6-0dbf9901d771.gif)

