### PR TITLE
docs: correction des quotas email

### DIFF
--- a/services/email.md
+++ b/services/email.md
@@ -52,7 +52,7 @@ Au cas où ils ne le sont pas, voici la liste complète :
 Le dossier `mail` est soumis à un quota de **5&nbsp;Go**.
 Cette déscision a été prise pour encourager la suppression des anciens emails.
 
-La taille maximale des emails (reçus et envoyés) est de **10&nbsp;Mo**.
+La taille maximale des emails (reçus et envoyés) est de **25&nbsp;Mo**.
 Si un email dépasse cette taille, il sera refusé et l'expéditeur en sera informé
 avec le message d'erreur : `Message size exceeds fixed limit` ou `552: 5.3.4 Error: message file too big`.
 


### PR DESCRIPTION
En réalité actuellement le quota de réception n'est pas de 100 Mo mais de 10 Mo.

Peut-être que ça serait une bonne idée de le passer plutôt à 25 Mo (comme pour matrix) ? Visiblement la plupart des boites email actuelles acceptent plus que 10 Mo.

_À merger en mode `Squash and merge`._