### PR TITLE
pdf: augmente la pénalité de pagebreak juste avant un bloc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
           echo '::remove-matcher owner=sphinx::'
   latex:
     runs-on: ubuntu-22.04
+    env:
+      SPHINXOPTS: --color
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -57,6 +57,12 @@
 % Interdit les titres de section dans le dernier quart de la page.
 \newcommand{\sectionbreak}{\needspace{.25\textheight}}
 
+% Augmente très légèrement la pénalité de pagebreak juste avant
+% une liste ou un bloc de code (valeur par défaut : -51).
+\makeatletter
+\@beginparpenalty=1
+\makeatother
+
 % Définition des paramètres de rendu de Sphinx.
 \sphinxsetup{
 	verbatimwithframe=true,
@@ -85,7 +91,9 @@
 
 % Définit une commande d'espacement spécifiquement utilisé pour l'index.
 % Remplis l'espace avec une ligne de points alignés verticalement.
+\makeatletter
 \newcommand \idxopen {\leavevmode \leaders \hb@xt@ .66em{\hss .\hss }\hfill \kern \z@}
+\makeatother
 
 % Customisation des tableaux.
 % Élargissement du padding des cellules.


### PR DESCRIPTION
Ou juste avant une liste.

#### avant
![2022-07-08-154802_768x447_scrot](https://user-images.githubusercontent.com/23519418/178005557-84058094-92a1-47cc-a7a2-25f38e0f743d.png)

#### après
![2022-07-08-154833_769x458_scrot](https://user-images.githubusercontent.com/23519418/178005561-3b0ea5da-8a80-4dcf-80ba-b6608b6ca681.png)
