### PR TITLE
docs: ajout de la définition de Apache + refs termes

### DIFF
--- a/glossaire.md
+++ b/glossaire.md
@@ -8,6 +8,11 @@ Glossaire
 sorted:
 ---
 
+Apache
+   {term}`Serveur` HTTP très populaire, distribué sous license libre.
+   HTTP étant le protocole du {term}`Web` on parle aussi souvent de "serveur Web".
+   --- [Wikipedia](https://fr.wikipedia.org/wiki/Apache_HTTP_Server)
+
 API
    De l'anglais _Application Programming Interface_.
    Interface destinée à être utilisée non pas par un être humain mais par un logiciel.

--- a/interne/meta-doc.md
+++ b/interne/meta-doc.md
@@ -1,7 +1,7 @@
 Meta-documentation
 ==================
 
-La documentation de CLUB1 est publiée au format HTML à l'adresse <https://club1.fr/docs/fr/>.
+La documentation de CLUB1 est publiée au format {term}`HTML` à l'adresse <https://club1.fr/docs/fr/>.
 Elle existe en deux langues : français, la principale et anglais, la secondaire.
 Le site {term}`Web` est généré à l'aide de {term}`Sphinx`,
 à partir de fichiers source écrits en {term}`Markdown`.
@@ -142,13 +142,13 @@ Sphinx
    Compilateur de documentation. --- [Wikipedia](https://fr.wikipedia.org/wiki/Sphinx_(g%C3%A9n%C3%A9rateur_de_documentation))
 
 MyST-Parser
-   Plugin Sphinx permettant la prise en charge du Markdown.
+   Extension {term}`Sphinx` permettant la prise en charge du {term}`Markdown`.
 
 Sphinx-rtd-theme
-   Plugin Sphinx fournissant le thème HTML ReadTheDocs.
+   Extension {term}`Sphinx` fournissant le thème {term}`HTML` ReadTheDocs.
 
 Sphinx-notfound-page
-   Plugin Sphinx pour générer une page d'erreur 404 personnalisée dont les liens sont absolus.
+   Extension {term}`Sphinx` permettant de générer une page d'erreur 404 personnalisée dont les liens sont absolus.
 
 gettext
    _(Optionnel)_ Pour les locales autres que Français.
@@ -211,8 +211,8 @@ juste au dessus du la ligne `msgid "..."` :
 Déploiement de la version Web
 -----------------------------
 
-Un [serveur HTTP Apache](https://fr.wikipedia.org/wiki/Apache_HTTP_Server)
-est requis pour le déploiement de la version Web de la documentation.
+Un serveur HTTP {term}`Apache`
+est requis pour le déploiement de la version {term}`Web` de la documentation.
 Ci-dessous se trouve un exemple de configuration Apache
 dans lequel la documentation se trouve dans `/var/www/docs`
 et où on veut la servir sous `/docs/` :

--- a/services/web.md
+++ b/services/web.md
@@ -16,7 +16,7 @@ sur le {term}`Web` à l'adresse `https://static.club1.fr`, par exemple :
 [`https://static.club1.fr/nicolas/test.html`](https://static.club1.fr/nicolas/test.html)
 &rarr; `/home/nicolas/static/test.html`
 
-Ce dossier est servi par le serveur HTTP [Apache](https://fr.wikipedia.org/wiki/Apache_HTTP_Server).
+Ce dossier est servi par le serveur HTTP {term}`Apache`.
 Il est configuré pour automatiquement générer un _index_ affichant la liste
 des fichiers et dossiers qu'il contient.
 


### PR DESCRIPTION
Apache était référencé à deux endroits de la doc. C'est le moment d'ajouter une entrée de glossaire.