### PR TITLE
Ajout de logiciels utilisés pour les emails

### DIFF
--- a/services/email.md
+++ b/services/email.md
@@ -103,7 +103,7 @@ SPF-Engine
 PostSRSd
    {term}`Serveur` de traitement SRS (_Sender Rewriting Scheme_)
    permettant à {term}`Postfix` de transférer des emails en restant compatible avec SPF.
-   [Sources](https://github.com/roehling/postsrsd)
+   --- [Sources](https://github.com/roehling/postsrsd)
 
 OpenDKIM
    {term}`Serveur` fournissant un filtre _milter_

--- a/services/email.md
+++ b/services/email.md
@@ -94,7 +94,7 @@ Dovecot
    {term}`Serveur` IMAP utilisé pour la gestion de boîtes emails.
    --- [Wikipedia](https://fr.wikipedia.org/wiki/Dovecot),
    [Sources](https://github.com/dovecot/core)
-   
+
 SPF-Engine
    {term}`Serveur` de traitement [SPF (_Sender Policy Framework_)](https://fr.wikipedia.org/wiki/Sender_Policy_Framework)
    utilisé par {term}`Postfix` pour vérifier l'origine des emails entrants.

--- a/services/email.md
+++ b/services/email.md
@@ -94,6 +94,16 @@ Dovecot
    {term}`Serveur` IMAP utilisé pour la gestion de boîtes emails.
    --- [Wikipedia](https://fr.wikipedia.org/wiki/Dovecot),
    [Sources](https://github.com/dovecot/core)
+   
+SPF-Engine
+   {term}`Serveur` de traitement [SPF (_Sender Policy Framework_)](https://fr.wikipedia.org/wiki/Sender_Policy_Framework)
+   utilisé par {term}`Postfix` pour vérifier l'origine des emails entrants.
+   --- [Sources](https://launchpad.net/spf-engine)
+
+PostSRSd
+   {term}`Serveur` de traitement SRS (_Sender Rewriting Scheme_)
+   permettant à {term}`Postfix` de transférer des emails en restant compatible avec SPF.
+   [Sources](https://github.com/roehling/postsrsd)
 
 OpenDKIM
    {term}`Serveur` fournissant un filtre _milter_


### PR DESCRIPTION
2 logiciels supplémentaires sont utilisés pour le service email.

À merger en mode "squash".