### PR TITLE
docs: infos à propos des sous-adresses

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -7,5 +7,6 @@
   "no-trailing-punctuation": { "punctuation": ".,;:" },
   "code-block-style": false,
   "emphasis-style": false,
+  "link-fragments": false,
   "first-line-heading": false
 }

--- a/glossaire.md
+++ b/glossaire.md
@@ -8,6 +8,12 @@ Glossaire
 sorted:
 ---
 
+Alias
+    Pseudonyme, nom de substitution. Les alias permettent de donner plusieurs noms à la même entité.
+    C'est un concept fréquemment utilisé en informatique.
+    On parle par exemple d'alias lorsqu'on fait pointer plusieurs adresses email vers la même boîte de reception,
+    ou lorsqu'on définit un nouveau nom pour une commande.
+
 API
    De l'anglais _Application Programming Interface_.
    Interface destinée à être utilisée non pas par un être humain mais par un logiciel.

--- a/interne/aliases.md
+++ b/interne/aliases.md
@@ -1,8 +1,8 @@
 Gestion des alias email
 =======================
 
-Ce tutoriel est réservé aux utilisateurs faisant partie du groupe unix `aliases`.
-Il décrit les actions que peuvent accomplir ces utilisateurs.
+Ce manuel est réservé aux utilisateurs faisant partie du groupe unix `aliases`.
+Il décrit les actions que peuvent accomplir ces utilisateurs sur les {term}`alias` emails.
 
 Modifier les alias de reception
 -------------------------------

--- a/services/email.md
+++ b/services/email.md
@@ -9,7 +9,7 @@ Sous-adresses
 -------------
 
 En plus de l'adresse principale, les membres ont la possibilité d'utiliser les sous-adresses.
-Les sous-adresses sont comme des alias.
+Les sous-adresses sont comme des {term}`alias`.
 Par défaut, elles redirigent vers l'adresse principale.
 Toutes les adresses de la forme `membre+[...]@club1.fr` sont des sous-adresses de `membre@club1.fr`
 

--- a/services/email.md
+++ b/services/email.md
@@ -5,6 +5,35 @@ Chaque membre dispose d'une adresse email personnelle.
 Elle est composée de l'**identifiant**, suivi de `@club1.fr`.
 Par exemple, l'adresse de l'utilisateur `michel` est `michel@club1.fr`.
 
+Sous-adresses
+-------------
+
+En plus de l'adresse principale, les membres ont la possibilité d'utiliser les sous-adresses.
+Les sous-adresses sont comme des alias.
+Par défaut, elles redirigent vers l'adresse principale.
+Toutes les adresses de la forme `membre+[...]@club1.fr` sont des sous-adresses de `membre@club1.fr`
+
+> Par exemple, tous les emails envoyés à `michel+travail@club1.fr`
+> seront redirigés vers `michel@club1.fr`.
+
+Ces adresses peuvent paraitre inutiles à première vue.
+Mais combinées avec les [transferts automatiques](#transferts-automatiques)
+et les [filtres automatiques](#filtres-automatiques),
+elles deviennent très intéressantes.
+
+```{important}
+Pour le [transfert automatique](#transferts-automatiques) d'une sous-adresse en particulier,
+on utilise un fichier `.formward+[...]` au lieu du fichier `.forward` de l'adresse principale.
+
+> Par exemple pour rediriger uniquement l'adresse `michel+travail@club1.fr`
+> il faut le faire dans le fichier `.forward+travail`.
+```
+
+```{admonition} Voir aussi
+La documentation officielle de l'option [recipient_delimiter](http://www.postfix.org/postconf.5.html#recipient_delimiter)
+(en anglais)
+```
+
 Client Web
 ----------
 


### PR DESCRIPTION
J'ai essayé de rendre ça clair mais c'est pas évident.
C'est peut-être un peu fort de mettre ça en première sous-sections mais je trouvais que ça allait bien en dessous du premier paragraphe.

Le warning du lien vers les filtre sera résolu une fois que #150 sera mergé.


Fix #148 