### PR TITLE
docs: premier ajout de la FAQ & précision email

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -1,0 +1,29 @@
+Foire aux questions
+===================
+
+Reponses aux questions fréquemment posées par rapport au serveur CLUB1.
+
+Questions
+---------
+
+```{contents}
+---
+depth: 1
+local: true
+backlinks: entry
+---
+```
+
+### Est ce que je peux héberger mes emails chez CLUB1 avec mon nom de domaine et créer plein d'adresses indépendantes ?
+
+Réponse courte : NON
+
+Réponse longue :
+CLUB1 fournit **[une seule boîte email](/services/email.md) par compte de membre**
+avec une adresse principale et toutes ses [sous-adresses](services/email.md#sous-adresses).
+Il est possible de créer des {term}`alias` personalisés à la demande,
+mais pas de créer des boîtes de reception supplémentaires.
+
+Si vous louez votre nom de domaine, il est probable que votre registraire
+(intermédiare chez qui vouz louez le nom de domaine) propose un service d'email inclus.
+Par exemple, [Gandi inclut ce service](https://docs.gandi.net/fr/gandimail/index.html) avec chaque nom de domaine loué.

--- a/index.md
+++ b/index.md
@@ -17,6 +17,7 @@ info/index
 services/index
 tutos/index
 interne/index
+faq
 glossaire
 ```
 

--- a/services/email.md
+++ b/services/email.md
@@ -1,8 +1,8 @@
 Messagerie email
 ================
 
-Chaque membre dispose d'une adresse email personnelle.
-Elle est composée de l'**identifiant**, suivi de `@club1.fr`.
+Chaque membre dispose d'**une boîte email** avec une adresse email personnelle.
+L'adresse est composée de l'**identifiant**, suivi de `@club1.fr`.
 Par exemple, l'adresse de l'utilisateur `michel` est `michel@club1.fr`.
 
 Sous-adresses


### PR DESCRIPTION
La FAQ comprends un sommaire. Il sera particulièrement utile lorsqu'elle contiendra beaucoup de questions-réponses.

Le style de titre `settext` (souligné) n'a pas besoin d'être respecté dans cette page. En effet les titres sont des questions complètes ce qui les rends très longs. Il serait fastidieux de tous les souligner manuellement jusqu'au bout. Et un soulignement partiel rendrait les titres étranges.

Des détails ont été ajoutés par rapport à l'unique boite email. C'est le gros point bloquant du service email actuel (et ça le restera probablement longtemps).


Closes #134 

P.S. haha le sommaire a un drôle de style dans la version pdf !
![2022-09-14-155954_826x342_scrot](https://user-images.githubusercontent.com/23519418/190175029-2b9f1d4e-f4ea-425b-952e-8dfac22c6d48.png)

-----------------------------

EDIT: Du coup j'ai désactivé cette boite ombrée dans https://github.com/club-1/docs/commit/b7d1bd2acd84d0f3acf9d198008164824c70382f :

![2022-09-15-133949_751x283_scrot](https://user-images.githubusercontent.com/23519418/190400656-fbc0770a-b97f-4bae-952b-3f4043350689.png)

J'ai hésité à essayer de faire une vrai tableofcontents $\LaTeX$ mais ça aurait été trop galère. Voilà à quoi ça aurait ressemblé :
![2022-09-15-134251_783x258_scrot](https://user-images.githubusercontent.com/23519418/190401388-7544405e-7d62-4229-af07-630b241e39d2.png)
