### PR TITLE
docs: utilisation de guilabel dans les tutos

### DIFF
--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -125,22 +125,22 @@
 	{\endmdframed}
 
 % Customisation des touches de clavier.
-\renewcommand\sphinxkeyboard[1]{%
+\DeclareRobustCommand{\sphinxkeyboard}[1]{%
   \tikz[baseline=(key.base)]
     \node[%
-      draw,
+      draw=white!30!gray,
       fill=white,
       drop shadow={shadow xshift=0pt,shadow yshift=-1pt,fill=gray,opacity=1,shadow scale=1},
       rectangle,
       rounded corners=2pt,
       inner sep=2pt,
       line width=0.2pt,
-      font=\scriptsize\sffamily
+      font=\footnotesize\sffamily
     ](key) {\vphantom{Q}#1};%
 }
 
 % Customisation des guilabels.
-\renewcommand\sphinxguilabel[1]{%
+\DeclareRobustCommand{\sphinxguilabel}[1]{%
   \tikz[baseline=(key.base)]
     \node[%
       draw=white!60!blue,
@@ -149,7 +149,7 @@
       rounded corners=2pt,
       inner sep=2pt,
       line width=0.2pt,
-      font=\scriptsize\sffamily
+      font=\footnotesize\sffamily
     ](key) {\vphantom{Q}#1};%
 }
 

--- a/tutos/caldav-mac.md
+++ b/tutos/caldav-mac.md
@@ -5,8 +5,8 @@ Cette méthode permet de synchroniser ses {index}`calendriers` entre le serveur 
 
 L'opération se fait directement depuis l'application Calendrier Apple.
 
-Dans la barre de menu il faut se rendre dans **Calendrier**
-puis **Comptes...** pour afficher la fenêtre de configuration de **Comptes Internet**
+Dans la barre de menu il faut se rendre dans {guilabel}`Calendrier`
+puis {guilabel}`Comptes...` pour afficher la fenêtre de configuration de **Comptes Internet**
 ({numref}`fig:tutos-caldav-mac-comptes`).
 
 ```{figure} caldav-mac/0.png
@@ -17,7 +17,7 @@ name: fig:tutos-caldav-mac-comptes
 Fenêtre "Comptes Internet".
 ```
 
-Pour ajouter un compte CLUB1 il faut cliquer sur **Ajouter un autre compte...**
+Pour ajouter un compte CLUB1 il faut cliquer sur {guilabel}`Ajouter un autre compte...`
 et choisir **Compte {term}`CalDAV`** ({numref}`fig:tutos-caldav-mac-autres-comptes`)
 
 ```{figure} caldav-mac/2.png
@@ -25,7 +25,7 @@ et choisir **Compte {term}`CalDAV`** ({numref}`fig:tutos-caldav-mac-autres-compt
 alt: capture d'écran fenêtre Autres Comptes
 name: fig:tutos-caldav-mac-autres-comptes
 ---
-La fenêtre "Comptes Internet" dévoile son plein potentiel une fois qu'on a cliqué sur le bouton "Ajouter un autres compte...".
+La fenêtre "Comptes Internet" dévoile son plein potentiel une fois qu'on a cliqué sur le bouton {guilabel}`Ajouter un autres compte...`.
 ```
 
 

--- a/tutos/connexion-linux.md
+++ b/tutos/connexion-linux.md
@@ -12,7 +12,7 @@ C'est l'explorateur de fichier installé par défaut sur [Linux Mint](https://fr
 Il est assez proche de celui qui est intégré à [Ubuntu](https://fr.wikipedia.org/wiki/Ubuntu_(syst%C3%A8me_d%27exploitation)),
 les instructions seront donc similaires.
 
-Dans la barre de menu, cliquez sur "fichier" puis "se connecter au serveur..."
+Dans la barre de menu, cliquez sur {guilabel}`fichier` puis {guilabel}`se connecter au serveur...`.
 
 Remplir ensuite les informations suivantes dans la fenêtre de connexion ({numref}`fig:tutos-connexion-linux-connexion`) :
 
@@ -23,7 +23,7 @@ Remplir ensuite les informations suivantes dans la fenêtre de connexion ({numre
 - Mot de passe : rentrez votre mot de passe CLUB1
 
 Pour finir vous pouvez cocher la case "Mémoriser ce mot de passe"
-afin de ne pas avoir à le retaper plus tard, puis cliquer sur "Se connecter".
+afin de ne pas avoir à le retaper plus tard, puis cliquer sur {guilabel}`Se connecter`.
 
 ```{figure} connexion-linux/se_connecter_au_serveur.png
 ---
@@ -54,8 +54,10 @@ Pour remédier à ce problème, il faut ajouter un **marque-page** (**bookmark**
 
 Selon votre explorateur de fichiers :
 
-- Depuis le *dossier perso* : dans la barre de menu, cliquez sur "Marque-pages" puis "Ajouter un marque-page"
-- Depuis le dossier `home` : clic droit sur votre *dossier perso* puis "ajouter marque-page", ou autre formulation similaire
+- Depuis le *dossier perso* : dans la barre de menu,
+  cliquez sur {guilabel}`Marque-pages` puis {guilabel}`Ajouter un marque-page`
+- Depuis le dossier `home` : clic droit sur votre *dossier perso*
+  puis {guilabel}`ajouter marque-page`, ou autre formulation similaire
 
 Vous pouvez désormais modifier tous vos fichiers facilement depuis votre explorateur de fichiers !
 

--- a/tutos/flux-rss.md
+++ b/tutos/flux-rss.md
@@ -24,13 +24,13 @@ Pour l'obtenir, vous pouvez visiter le site en question avec un navigateur web
 depuis lequel il est possible de copier l'URL depuis la barre de recherche.
 ```
 
-Une fois connectés, cliquez en haut à droite sur le logo de menu à 3 barres, puis sur `s'abonner au flux...`
+Une fois connectés, cliquez en haut à droite sur le logo de menu à 3 barres, puis sur {guilabel}`s'abonner au flux...`
 
 ![visualisation du menu](flux-rss/capture_1.png)
 
 Entrez l'url du site dont vous voulez obtenir le {term}`flux de nouvelles`, par exemple ici le blog de Fred Turner.
 Si vous avez créé des catégories, vous pouvez en sélectionner une pour trier votre flux (c'est possible de le faire plus tard)
-puis cliquez sur `S'abonner`.
+puis cliquez sur {guilabel}`S'abonner`.
 
 ```{warning}
 Il est possible qu'un site ne propose pas de flux de nouvelles,
@@ -61,7 +61,8 @@ Les catégories permettent de rassembler les flux auxquels vous vous êtes abonn
 Elles sont utiles par exemple pour recréer un sous-fil d'actualités thématique,
 surtout lorsqu'on est abonné à beaucoup de sites.
 
-Pour créer une catégorie, il faut retourner dans le menu en haut à droite de l'écran principal et cliquer sur `Configuration...`.
+Pour créer une catégorie, il faut retourner dans le menu en haut à droite de l'écran principal
+et cliquer sur {guilabel}`Configuration...`.
 Aller dans l'onglet Flux en haut de l'écran.
 
 ![Config catégories 1](flux-rss/capture_4.png)
@@ -87,7 +88,7 @@ vous pouvez désactiver le "mode combiné" dans la configuration.
 Il est possible de passer en mode _trois colones_ avec le panneau de lecture à droite,
 ce qui est pratique lorsqu'on a un écran large.
 
-Ceci se fait depuis le menu, en cliquant sur `Basculer le mode écran large`.
+Ceci se fait depuis le menu, en cliquant sur {guilabel}`Basculer le mode écran large`.
 ```
 
 

--- a/tutos/presentation.md
+++ b/tutos/presentation.md
@@ -70,3 +70,7 @@ Par exemple, l'adresse suivante ouvrira directement la présentation du membre `
     https://club1.fr/membres/#vincent
 
 
+
+```{raw} latex
+\clearpage
+```

--- a/tutos/webdav-android.md
+++ b/tutos/webdav-android.md
@@ -14,7 +14,7 @@ ou gratuite sur [F-droid](https://fr.wikipedia.org/wiki/F-Droid)
 [*open sources*](https://fr.wikipedia.org/wiki/Open_source) et sans pubs).
 
 - [F-Droid](https://f-droid.org/fr/packages/at.bitfire.davdroid/)
-- [Google Plays store](https://play.google.com/store/apps/details?id=at.bitfire.davdroid&hl=fr&gl=FR) (6€)
+- [Google Play store](https://play.google.com/store/apps/details?id=at.bitfire.davdroid&hl=fr&gl=FR) (6€)
 
 Premier lancement
 -----------------

--- a/tutos/webdav-mac.md
+++ b/tutos/webdav-mac.md
@@ -1,7 +1,7 @@
 Accès à l'espace personnel depuis le Finder d'un Mac
 ====================================================
 
-Dans le Finder, dans la barre de menu, cliquez sur `Aller` --> `Se connecter au serveur...`
+Dans le Finder, dans la barre de menu, cliquez sur {guilabel}`Aller` --> {guilabel}`Se connecter au serveur...`.
 
 ![aller](webdav-mac/screen_001.png)
 
@@ -18,15 +18,15 @@ Rentrez l'url Webdav correspondant à votre utilisateur :
 En utilisant votre login CLUB1.
 
 
-Cliquez sur le bouton `+` en bas à gauche de la fenêtre pour garder en mémoire l'adresse de votre serveur dans les favoris.
+Cliquez sur le bouton {guilabel}`+` en bas à gauche de la fenêtre pour garder en mémoire l'adresse de votre serveur dans les favoris.
 
-Puis, cliquez sur le bouton `Connexion`.
+Puis, cliquez sur le bouton {guilabel}`Connexion`.
 
 ![aller](webdav-mac/screen_003.png)
 
-Une fenêtre pop-up va apparaître vous demandant vos identifiants chez Club1.
+Une fenêtre pop-up va apparaître vous demandant vos identifiants CLUB1.
 
-Cliquez sur le bouton Se connecter.
+Cliquez sur le bouton {guilabel}`Se connecter`.
 
 ![aller](webdav-mac/screen_004.png)
 
@@ -39,16 +39,21 @@ car ceci permettra de déverouiller l'accès entre vos ouvertures/fermetures de 
 
 
 
-Votre dossier personnel Club1 devrait s'afficher et être listé dans les Emplacements de votre Finder.
+Votre dossier personnel CLUB1 devrait s'afficher et être listé dans les Emplacements de votre Finder.
 
 A présent, il faut péréniser cet accès en l'ajoutant aux favoris.
 Pour se faire, il nous faut accèder au dossier parent.
 
-Depuis la barre de menu cliquez sur `Aller` --> `Dossier parent` (ou via le raccourci clavier : `CMD` + `↑`).
+Depuis la barre de menu cliquez sur {guilabel}`Aller` --> {guilabel}`Dossier parent`
+(ou via le raccourci clavier : {kbd}`Cmd` + {kbd}`↑`).
 
-Maintenant, il est possbile de cliquer-glisser votre dossier perso dans la zone de favoris.
+Maintenant, il est possible de cliquer-glisser votre dossier perso dans la zone de favoris.
 
 ![aller](webdav-mac/screen_007.png)
 
 
-Votre dossier dans le serveur Club1 est dorénavant accessible en tout temps et simplement !
+Votre dossier dans le serveur CLUB1 est dorénavant accessible en tout temps et simplement !
+
+```{raw} latex
+\clearpage
+```


### PR DESCRIPTION
Et peaufinage de l'affichage des `guilabel` et `kbd` en latex.
& Corrections de mini fautes.

Sphinx a un role prévu exprès pour les boutons de GUI. Comme ça on a plus besoin de se demander si on doit les mettre **en gras**, "entre guillemets", ou `en code`. 

HTML:
![2022-12-31-142037_626x264_scrot](https://user-images.githubusercontent.com/23519418/210138142-0d571b94-c7cf-4359-bb67-c9369214bf67.png)


PDF:
![2022-12-31-141607_962x260_scrot](https://user-images.githubusercontent.com/23519418/210138117-27034079-6878-46ca-8f62-c02108e0dfc9.png)
