### PR TITLE
docs: utilisation de {seealso}

### DIFF
--- a/info/espace-personnel.md
+++ b/info/espace-personnel.md
@@ -69,7 +69,7 @@ il faut créer un **fichier de présentation** appellé `PRESENTATION.md` à la 
 Il est possible de formater son texte en {term}`Markdown`,
 ainsi que de changer son nom d'affichage et la couleur de son bouton.
 
-```{admonition} Voir aussi
+```{seealso}
 Tutoriel : [Comment éditer sa présentation](/tutos/presentation.md)
 ```
 

--- a/info/general.md
+++ b/info/general.md
@@ -118,7 +118,7 @@ Les sauvegardes sont réparties en deux groupes :
 1. **System** pour la configuration du serveur, les fichiers des applications et les bases de données.
 2. **Userdata** pour les données de l'_espace personnel_ (dossier `home`).
 
-```{admonition} Voir aussi
+```{seealso}
 L'article du journal [Sauvegardes](https://club1.fr/backups/)
 ```
 

--- a/info/politique-de-vie-privee.md
+++ b/info/politique-de-vie-privee.md
@@ -3,7 +3,7 @@ Politique de vie privée
 
 Nos engagements en matière de vie privée.
 
-```{admonition} Voir aussi
+```{seealso}
 Nos engagement dans les [CGU](../cgu.md#nos-engagements)
 ```
 

--- a/services/email.md
+++ b/services/email.md
@@ -29,7 +29,7 @@ on utilise un fichier `.formward+[...]` au lieu du fichier `.forward` de l'adres
 > il faut le faire dans le fichier `.forward+travail`.
 ```
 
-```{admonition} Voir aussi
+```{seealso}
 La documentation officielle de l'option [recipient_delimiter](http://www.postfix.org/postconf.5.html#recipient_delimiter)
 (en anglais)
 ```
@@ -67,7 +67,7 @@ Détails divers
 
 Quelques informations supplémentaires à propos de certains détails du service email de CLUB1.
 
-```{admonition} Voir aussi
+```{seealso}
 L'article du journal [Le(s) serveur(s) email](https://club1.fr/email/)
 ```
 
@@ -121,7 +121,7 @@ en ajoutant son nom d'utilisateur&middot;trice à cette liste !
 Pour mettre fin à une redirection, il suffit de supprimer la ligne correspondante.
 Il est aussi possible de supprimer le fichier pour tout annuler.
 
-```{admonition} Voir aussi
+```{seealso}
 La page de manuel [Postfix local mail delivery](https://www.postfix.org/local.8.html) (en anglais)
 ```
 
@@ -200,7 +200,7 @@ Roundcube
    --- [Wikipedia](https://fr.wikipedia.org/wiki/Roundcube),
    [Sources](https://github.com/roundcube/roundcubemail)
 
-   ```{admonition} Voir aussi
+   ```{seealso}
    La section [](#client-web)
    ```
 ````

--- a/services/web.md
+++ b/services/web.md
@@ -67,7 +67,7 @@ ligne suivante.
 Options -Indexes
 ```
 
-```{admonition} Voir aussi
+```{seealso}
 Le tutoriel "[](/tutos/mes-premiers-pas-sur-le-web.md)" pour apprendre à faire son premier site web avec le dossier `/static`.
 ```
 


### PR DESCRIPTION
à la place de l'admonition custom. Pourquoi j'avais fait ce choix ??
Résoud les warning lors de la compilation dans un language secondaire
