### PR TITLE
docs: minuscules dans le glossaire pour les noms communs

### DIFF
--- a/_locales/en/LC_MESSAGES/package.po
+++ b/_locales/en/LC_MESSAGES/package.po
@@ -432,7 +432,7 @@ msgid "Glossaire"
 msgstr "Glossary"
 
 #: ../../glossaire.md:0
-msgid "Adresse IP"
+msgid "adresse IP"
 msgstr "IP address"
 
 #: ../../glossaire.md:8
@@ -468,8 +468,8 @@ msgstr ""
 "en.wikipedia.org/wiki/IP_address)"
 
 #: ../../glossaire.md:13
-msgid "Alias"
-msgstr "Alias"
+msgid "alias"
+msgstr "alias"
 
 #: ../../glossaire.md:21
 msgid ""
@@ -511,8 +511,8 @@ msgstr ""
 "(https://en.wikipedia.org/wiki/Command-line_interface)"
 
 #: ../../glossaire.md:32
-msgid "Client"
-msgstr "Client"
+msgid "client"
+msgstr "client"
 
 #: ../../glossaire.md:40
 msgid ""
@@ -525,7 +525,7 @@ msgstr ""
 "by a human. --- [Wikipedia](https://en.wikipedia.org/wiki/Client_(computing))"
 
 #: ../../glossaire.md:37 ../../services/email.md:37
-msgid "Client Web"
+msgid "client Web"
 msgstr "Web client"
 
 #: ../../glossaire.md:45
@@ -536,11 +536,11 @@ msgstr ""
 "{term}`Client` accessible via the {term}`Web` and executed by a Web browser."
 
 #: ../../glossaire.md:40
-msgid "Fichier caché"
-msgstr "Hidden file"
+msgid "fichier caché"
+msgstr "hidden file"
 
 #: ../../glossaire.md:41
-msgid "Dossier caché"
+msgid "dossier caché"
 msgstr "hidden folder"
 
 #: ../../glossaire.md:49
@@ -647,8 +647,8 @@ msgstr ""
 "en.wikipedia.org/wiki/PHP)"
 
 #: ../../glossaire.md:91
-msgid "Réseau informatique"
-msgstr "Computer network"
+msgid "réseau informatique"
+msgstr "computer network"
 
 #: ../../glossaire.md:99
 msgid ""
@@ -660,8 +660,8 @@ msgstr ""
 "[Wikipedia](https://en.wikipedia.org/wiki/Computer_network)"
 
 #: ../../glossaire.md:95
-msgid "Serveur"
-msgstr "Server"
+msgid "serveur"
+msgstr "server"
 
 #: ../../glossaire.md:103
 msgid ""
@@ -2732,10 +2732,6 @@ msgstr ""
 "less strict than its competitor {term}`Atom`. --- [Wikipedia](https://en."
 "wikipedia.org/wiki/RSS)"
 
-#: ../../services/rss.md:17
-msgid "Atom"
-msgstr ""
-
 #: ../../services/rss.md:23
 msgid ""
 "Format de {term}`flux Web`. Ce format est plus strict et mieux standardisé "
@@ -3108,8 +3104,8 @@ msgid ""
 "OpenClassromm](https://openclassrooms.com/fr/courses/1603881-creez-votre-"
 "site-web-avec-html5-et-css3) de Mathieu Nebra."
 msgstr ""
-"To learn how to code in HTML and CSS, we often recommend Mathieu Nebra's ["
-"OpenClassromm tutorial](https://openclassrooms.com/fr/courses/1603881-creez-"
+"To learn how to code in HTML and CSS, we often recommend Mathieu Nebra's "
+"[OpenClassromm tutorial](https://openclassrooms.com/fr/courses/1603881-creez-"
 "votre-site-web-avec-html5-et-css3)."
 
 #: ../../services/web.md:38
@@ -3370,8 +3366,8 @@ msgid ""
 "tirets `-`."
 msgstr ""
 "Remember to check that the **subdomain** is available before sending a "
-"request! 😉 It must only consist of lowercase letters, numbers or hyphens "
-"`-`."
+"request! 😉 It must only consist of lowercase letters, numbers or hyphens `-"
+"`."
 
 #: ../../services/web.md:164
 msgid "Avoir des sous-sous-domaine"
@@ -3832,8 +3828,8 @@ msgid ""
 "Ce tutoriel explique comment utiliser [l'agrégateur de flux Web de CLUB1](/"
 "services/rss.md)."
 msgstr ""
-"This tutorial explains how to use [CLUB1's Web feed aggregator](/services/rss"
-".md)."
+"This tutorial explains how to use [CLUB1's Web feed aggregator](/services/"
+"rss.md)."
 
 #: ../../tutos/flux-rss.md:6
 msgid ""

--- a/_locales/package.pot
+++ b/_locales/package.pot
@@ -346,7 +346,7 @@ msgid "Glossaire"
 msgstr ""
 
 #: ../../glossaire.md:0
-msgid "Adresse IP"
+msgid "adresse IP"
 msgstr ""
 
 #: ../../glossaire.md:8
@@ -373,7 +373,7 @@ msgid ""
 msgstr ""
 
 #: ../../glossaire.md:13
-msgid "Alias"
+msgid "alias"
 msgstr ""
 
 #: ../../glossaire.md:21
@@ -404,7 +404,7 @@ msgid ""
 msgstr ""
 
 #: ../../glossaire.md:32
-msgid "Client"
+msgid "client"
 msgstr ""
 
 #: ../../glossaire.md:40
@@ -415,7 +415,7 @@ msgid ""
 msgstr ""
 
 #: ../../glossaire.md:37 ../../services/email.md:37
-msgid "Client Web"
+msgid "client Web"
 msgstr ""
 
 #: ../../glossaire.md:45
@@ -425,11 +425,11 @@ msgid ""
 msgstr ""
 
 #: ../../glossaire.md:40
-msgid "Fichier caché"
+msgid "fichier caché"
 msgstr ""
 
 #: ../../glossaire.md:41
-msgid "Dossier caché"
+msgid "dossier caché"
 msgstr ""
 
 #: ../../glossaire.md:49
@@ -506,7 +506,7 @@ msgid ""
 msgstr ""
 
 #: ../../glossaire.md:91
-msgid "Réseau informatique"
+msgid "réseau informatique"
 msgstr ""
 
 #: ../../glossaire.md:99
@@ -517,7 +517,7 @@ msgid ""
 msgstr ""
 
 #: ../../glossaire.md:95
-msgid "Serveur"
+msgid "serveur"
 msgstr ""
 
 #: ../../glossaire.md:103

--- a/glossaire.md
+++ b/glossaire.md
@@ -8,7 +8,7 @@ Glossaire
 sorted:
 ---
 
-Adresse IP
+adresse IP
    Numéro d'identification d'un ordinateur relié à un {term}`réseau informatique`.
 
    Le protocole IP (créé à l'origine pour {term}`Internet`) permet d'acheminer des données entre un ordinateur source et sa destination.
@@ -21,7 +21,7 @@ Adresse IP
    (ex : `2001:861:38c4:18a0::3` pour le serveur de CLUB1).
    --- [Wikipedia](https://fr.wikipedia.org/wiki/Adresse_IP)
 
-Alias
+alias
     Pseudonyme, nom de substitution. Les alias permettent de donner plusieurs noms à la même entité.
     C'est un concept fréquemment utilisé en informatique.
     On parle par exemple d'alias lorsqu'on fait pointer plusieurs adresses email vers la même boîte de reception,
@@ -40,16 +40,16 @@ CLI
    La CLI est très intéressante car elle peut aussi bien être utilisée par des humains que par des logiciels. ---
    [Wikipedia](https://fr.wikipedia.org/wiki/Interface_en_ligne_de_commande)
 
-Client
+client
    Logiciel permettant de se connecter à un {term}`serveur`.
    Il est en général doté d'une interface graphique, destinée à être utilisée directement par un humain. ---
    [Wikipedia](https://fr.wikipedia.org/wiki/Client_(informatique))
 
-Client Web
+client Web
    {term}`Client` accessible via le {term}`Web` et ainsi exécuté par un Navigateur web.
 
-Fichier caché
-Dossier caché
+fichier caché
+dossier caché
    Dans la plupart des systèmes d'exploitation,
    il est possible de cacher des fichiers ou des dossiers.
    Cela sert souvent à masquer des paramètres peu utiles au quotidien.
@@ -83,7 +83,7 @@ Internet
    Il s'agit donc d'un "réseau de réseaux". ---
    [Wikipedia](https://fr.wikipedia.org/wiki/Internet)
 
-Log
+log
    Designe à l'origine le [journal de bord (logbook)](https://fr.wikipedia.org/wiki/Livre_de_bord) d'un navire.
    En informatique il s'agit d'un journal contenant un historique d'événements,
    généralement sous la forme de ficher en texte brut.
@@ -105,11 +105,11 @@ PHP
    et c'est justement le langage que CLUB1 met en avant pour la création de [sites Web dynamiques](./services/web.md#sites-web-dynamiques).
    --- [Wikipedia](https://fr.wikipedia.org/wiki/PHP)
 
-Réseau informatique
+réseau informatique
    Ensemble d'ordinateurs reliés entre eux pour leur permettre d'échanger des données. ---
    [Wikipedia](https://fr.wikipedia.org/wiki/R%C3%A9seau_informatique)
 
-Serveur
+serveur
    Logiciel chargé de fournir un service. C'est lui qui détient les données
    et qui répond aux demandes d'un {term}`client`.
    Souvent, les serveurs et les clients sont installés sur des ordinateurs différents.


### PR DESCRIPTION
C'est finalment plus cohérent.
