### PR TITLE
Intégration de la barre d'entête de CLUB1

### DIFF
--- a/_static/club1.css
+++ b/_static/club1.css
@@ -65,7 +65,6 @@ dt:target {
 
 /* Fix navbar scroll until bottom */
 .rst-current-version {height: 2.5rem; /* lock version selector's height */}
-.wy-nav-side {padding-bottom: 2.5rem; /* set correct padding for the nav */}
 
 /* Disable scroll in version selector */
 .rst-versions.shift-up {
@@ -80,3 +79,53 @@ dt:target {
 .rst-content tt {
 	font-family: Noto Mono,Liberation Mono,SFMono-Regular,Consolas,monospace !important;
 }
+
+
+
+/* make Sphinx rtd theme work nicely with CLUB1 header */
+
+.wy-side-scroll {
+	padding-bottom: 3rem;
+}
+
+@media screen and (min-width: 769px) {
+	.wy-grid-for-nav {
+		height: initial;
+		display: flex;
+	}
+
+	.wy-nav-side {
+		position: sticky;
+		min-height: 100vh;
+		flex-shrink: 0;
+		align-self: flex-start;
+	}
+
+	.wy-nav-content-wrap {
+		margin-left: 0;
+	}
+
+	.wy-body-for-nav {
+		background: initial;
+	}
+
+	.wy-side-scroll {
+		/* height: 100%; */
+		max-height: calc(100vh - 2.5rem);
+		padding-bottom: 4rem;
+	}
+}
+
+@media screen and (max-width: 768px) {
+	.wy-grid-for-nav {
+		position: initial;
+	}
+	.wy-nav-content-wrap.shift {
+		top: 30px;
+	}
+	.wy-nav-side.shift {
+		top: 30px;
+		min-height: calc(100% - 30px);
+	}
+}
+

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -11,8 +11,24 @@
 	{% endfor %}
 {% endblock %}
 
-{% block sidebartitle %}
-{# Add a link to the main website #}
-	<a href="https://club1.fr" class="fa fa-arrow-left" > {{ _("Retour au site principal") }} </a><br>
-	{{ super() }}
+{% block extrabody %}
+<style>
+.club1header a:hover {
+  text-decoration: underline;
+}
+.club1header a {
+  text-decoration: none;
+  margin: 5px;
+}
+</style>
+
+<div class="club1header">
+  <div style="z-index: 1000; position: absolute; top:0; left:0; height: 30px;width: 100%;text-align: left;background: black; color: white; font-family: monospace; font-size: 15px;line-height: 30px;">
+    <span>CLUB1</span>
+    <a href="https://club1.fr/le-club/" style="color: white;">site web</a>
+    <a href="https://forum.club1.fr" style="color: white;">forum</a>
+    <a href="https://club1.fr/docs/fr/" style="color: white; text-decoration: underline;">documentation</a>
+  </div>
+  <div style="height: 30px;"></div>
+</div>
 {% endblock %}

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -23,8 +23,7 @@
 </style>
 
 <div class="club1header">
-  <div style="z-index: 1000; position: absolute; top:0; left:0; height: 30px;width: 100%;text-align: left;background: black; color: white; font-family: monospace; font-size: 15px;line-height: 30px;">
-    <span>CLUB1</span>
+  <div style="z-index: 1000; position: absolute; top:0; left:0; height: 30px;width: 100%;text-align: left;background: #272525; color: white; font-family: monospace; font-size: 15px;line-height: 30px;">
     <a href="https://club1.fr/le-club/" style="color: white;">site web</a>
     <a href="https://forum.club1.fr" style="color: white;">forum</a>
     <a href="https://club1.fr/docs/fr/" style="color: white; text-decoration: underline;">documentation</a>

--- a/conf.py
+++ b/conf.py
@@ -181,6 +181,7 @@ html_theme_options = {
     'prev_next_buttons_location': 'bottom',
     'style_external_links': False,
     'vcs_pageview_mode': 'blob',
+    'sticky_navigation': False,
     'navigation_with_keys': True,
 }
 


### PR DESCRIPTION
Il reste juste un défaut : les pages lorsqu'elles sont chargées scrollent juste en dessous de la barre. C'est dû à un morceau de JavaScript du thème que je ne peux pas vraiment modifier simplement. C'est un peu dommage mais ça ira non ?

![Peek 2023-02-02 17-31](https://user-images.githubusercontent.com/23519418/218512486-ad1bbf90-2206-4732-8e7a-60311f0d702f.gif)
![Peek 2023-02-13 17-17](https://user-images.githubusercontent.com/23519418/218512494-2cadb005-12b8-4ce0-a81b-5926b3f3d5ab.gif)
