### PR TITLE
Ajout du rôle "commande" et configuration des manpages

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -130,6 +130,9 @@ downloads = os.environ.get('DOWNLOADS', '').split(' ')
 # The domain is used for code documentation, so no need for it here.
 primary_domain = None
 
+# Template used for manpage role
+manpages_url = 'https://manpages.debian.org/{path}.' + language
+
 # Title used for BibTeX citation
 citation_bibtex_title = _('Documentation {CLUB1}')
 
@@ -302,3 +305,4 @@ def setup(app: Sphinx):
     app.connect('builder-inited', override_html_permalink_icon)
     # Add custom 'software' directive and refs
     app.add_object_type('logiciel', 'logiciel', 'pair: %s; ' + _('logiciel'), ref_nodeclass=nodes.inline)
+    app.add_object_type('commande', 'commande', 'pair: %s; ' + _('commande'))

--- a/faq.md
+++ b/faq.md
@@ -17,7 +17,7 @@ backlinks: entry
 ### Comment modifier mon mot de passe de membre CLUB1 ?
 
 Pour le moment, la seule manière de modifier son mot de passe de membre CLUB1
-est de lancer la commande [`passwd`](tutos/premiere-connexion-ssh.md#passwd) à partir d'une [connexion SSH](services/ssh.md).
+est de lancer la commande {commande}`passwd` à partir d'une [connexion SSH](services/ssh.md).
 
 ### Est ce que je peux héberger mes emails chez CLUB1 avec mon nom de domaine et créer plein d'adresses indépendantes ?
 

--- a/services/ssh.md
+++ b/services/ssh.md
@@ -32,7 +32,7 @@ l'**échange des clés**. Pour éviter de subir une
 il nous faut être sûr d'avoir reçu la bonne clé lors de cet échange.
 
 Si vous ne savez pas comment ajouter la clé du serveur à votre appareil,
-[ce tuto](/tutos/premiere-connexion-ssh.md) est fait pour vous !
+le tuto [](/tutos/premiere-connexion-ssh.md) est fait pour vous !
 ```
 
 Il existe deux manières de s'authentifier lors d'une connexion SSH.

--- a/tutos/premiere-connexion-ssh.md
+++ b/tutos/premiere-connexion-ssh.md
@@ -109,12 +109,14 @@ car c'est celui qui vous donne le plus de libertés d'interactions avec le serve
 
 🍾 Pour fêter ça, voici une petite sélection de commandes à découvrir :
 
-### `passwd`
-
+```{commande} passwd
 Permet de changer son mot de passe CLUB1
-(cela aura donc un effet sur la connexion à tout les [services](/services/index.md)).
+(cela aura donc un effet sur la connexion à tous les [services](/services/index.md)).
+--- Manuel : {manpage}`passwd.1`
+```
 
-### `htop`
-
+```{commande} htop
 Permet de voir ce qui se passe sur le serveur en ce moment et à quel point les ressources sont utilisées.
 Pressez la touche {kbd}`Q` pour quitter.
+--- Manuel : {manpage}`htop.1`
+```


### PR DESCRIPTION
Comme il est prévu d'ajouter à un moment une petite liste de commandes SSH à utiliser sur le serveur, il serait utile de facilement pouvoir les référencer.

On en a déjà un exemple avec la commande `passwd`.

Le rôle "manpages" est lui intégré à Sphinx. Il est configuré pour automatiquement créer un lien vers les pages de manuel de Debian. Je trouve le visionneur de page de manuel de Debian vraiment sympa car il a une mise en page assez moderne et responsive. Et aussi il prends en compte les différents languages dans lesquels sont des fois traduites ces pages.

Par exemple la page de la commande `passwd` en français (bon elle n'est pas entièrement traduite mais c'est mieux que rien) : https://manpages.debian.org/bullseye/passwd/passwd.1.fr.html