### PR TITLE
docs: ajout des 2 extensions Flarum maintenues pas CLUB1

### DIFF
--- a/outils/forum.md
+++ b/outils/forum.md
@@ -74,14 +74,27 @@ directement depuis {logiciel}`Nginx`.
 
 Il utilise une base de données {term}`SQL` gérée par {logiciel}`MariaDB`.
 
-```{logiciel} Flarum
+````{logiciel} Flarum
 Logiciel de forum écrit en {term}`PHP`.
 Il est concu pour être extrêmement modulaire
 avec très peu de fonctionnalités faisant réellement partie du c&oelig;ur.
 Il est ainsi facile d'en développer des extensions de toute sorte,
 qui peuvent emmener l'outil forum dans des directions très différentes.
 --- [Sources](https://github.com/flarum/framework/), [Site](https://flarum.org/)
+
+CLUB1 maintient plusieurs extension pour ce forum :
+
+```{describe} club-1/flarum-ext-cross-references
+Ajoute des liens de référence croisé lorsqu'une discussion est mentionnée depuis une autre.
+--- [Sources](https://github.com/club-1/flarum-ext-cross-references)
 ```
+
+```{describe} club-1/flarum-ext-french-typography
+Typographie améliorée pour les écrits français, principalement autour de la ponctuation.
+--- [Sources](https://github.com/club-1/flarum-ext-french-typography)
+```
+
+````
 
 ### Fichiers et dossiers
 


### PR DESCRIPTION
Plus tard ça pourrait être intéressant d'ajouter toutes les extension Flarum installées.
Même si ça fait pas mal de travail et qu'il faudra maintenir la liste à jour.

Je pense que ça pourrait être intéressant d'ajouter une directive spécialisée pour ça,
plutôt que d'utiliser {logiciel} pour remplacer l'actuel {describe} très générique.
De cette manière on pourrait choisir de ne pas ajouter d'entrées d'index, ou bien seulement
une sous-entrée de "extensions Flarum" par exemple.
