### PR TITLE
Mise-à-jour vers Sphinx 6

### DIFF
--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,4 +1,4 @@
-sphinx @ git+https://github.com/sphinx-doc/sphinx/@8f9bac9c4f5d399f8085870dd30570aa32bbf48a
+sphinx == 6.2.1
 myst-parser @ git+https://github.com/executablebooks/MyST-Parser@2a206a8777a004c9be3c6138ed8c7505771c8567 # 0.18.1 + some fixes + support for Sphinx 6
 sphinx-rtd-theme == 1.2.1
 sphinx-notfound-page == 0.8.3

--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,4 +1,4 @@
-sphinx == 5.3.0
+sphinx @ git+https://github.com/sphinx-doc/sphinx/@8f9bac9c4f5d399f8085870dd30570aa32bbf48a
 myst-parser @ git+https://github.com/executablebooks/MyST-Parser@2a206a8777a004c9be3c6138ed8c7505771c8567 # 0.18.1 + some fixes + support for Sphinx 6
 sphinx-rtd-theme == 1.2.1
 sphinx-notfound-page == 0.8.3

--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -110,9 +110,9 @@
 	linecolor=lightgray,
 	linewidth=3pt,
 	rightline=false, topline=false, bottomline=false,
-	innerleftmargin=16pt, innerrightmargin=0pt,
-	innertopmargin=5pt, innerbottommargin=4pt,
-	skipabove=8pt, skipbelow=10pt,
+	innerleftmargin=15pt, innerrightmargin=0pt,
+	innertopmargin=4pt, innerbottommargin=3pt,
+	skipabove=9pt,
 }
 \renewenvironment{quote}
 	{\par\mdframed[style=QuoteFrame]}

--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -160,7 +160,8 @@
 
 \newenvironment{club1admonition}[3]{\begin{tcolorbox}[
 	boxrule=0pt, frame empty, % no borders
-	before=\par, parbox=false, % obey document paragraph spacing rules
+	before=\par\noindent, % respect space around box
+	before upper=\setlength{\parskip}{5pt}, % space between paragraphs
 	colbacktitle=#2, colback=#3, % colors
 	outer arc=0pt, arc=0pt, % no border radius
 	left=5pt, right=5pt, top=5pt, bottom=5pt, % body margins

--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -158,9 +158,6 @@
     (-0.8,3) -- (0.8,3) -- (0.7,-1) -- (-0.7,-1) -- cycle;
 }}
 
-\def\StriplastColon#1{\striplastColon{#1}#1\end :\end\eend}
-\def\striplastColon#1#2:\end#3\eend{\ifx\end#3\end#1\else#2\fi}
-
 \newenvironment{club1admonition}[3]{\begin{tcolorbox}[
 	boxrule=0pt, frame empty, % no borders
 	before=\par, parbox=false, % obey document paragraph spacing rules
@@ -169,7 +166,7 @@
 	left=5pt, right=5pt, top=5pt, bottom=5pt, % body margins
 	toptitle=1pt, bottomtitle=1pt, % title bar margins
 	fonttitle=\sffamily\bfseries, % same font variant as other titles
-	title=\raisebox{-.1\height}{\tikz\pic{ExclamationCircle};} \StriplastColon{#1}
+	title=\raisebox{-.1\height}{\tikz\pic{ExclamationCircle};} \sphinxremovefinalcolon{#1}
 ]}{\end{tcolorbox}}
 
 \definecolor{colTipHead}{HTML}{18BC9B}

--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -63,7 +63,8 @@
 % Définition des paramètres de rendu de Sphinx.
 \sphinxsetup{
 	verbatimwithframe=true,
-	VerbatimColor={named}{MintCream},
+	pre_border-radius=0pt,
+	pre_background-TeXcolor={named}{MintCream},
 	% TitleColor={named}{DarkGoldenrod},
 }
 

--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -180,6 +180,8 @@
 \definecolor{colWarningBody}{HTML}{FEECCA}
 \definecolor{colErrorHead}{HTML}{F19F97}
 \definecolor{colErrorBody}{HTML}{FDF3F2}
+\renewenvironment{sphinxseealso}[1]
+	{\begin{club1admonition}{#1}{colNoteHead}{colNoteBody}}{\end{club1admonition}}
 \renewenvironment{sphinxnote}[1]
 	{\begin{club1admonition}{#1}{colNoteHead}{colNoteBody}}{\end{club1admonition}}
 \renewenvironment{sphinxhint}[1]

--- a/_templates/club1.sty
+++ b/_templates/club1.sty
@@ -66,6 +66,9 @@
 	pre_border-radius=0pt,
 	pre_background-TeXcolor={named}{MintCream},
 	% TitleColor={named}{DarkGoldenrod},
+	TableRowColorHeader={gray}{1},
+	TableRowColorOdd={gray}{0.95},
+	TableRowColorEven={gray}{1},
 }
 
 % Augmentation de la marge intérieure.
@@ -99,16 +102,6 @@
 \renewcommand\arraystretch{1.5} % vertical
 % Style de texte de la ligne de titre (Sans serif gras).
 \renewcommand\sphinxstyletheadfamily{\sffamily\bfseries}
-% Alterne le fond des lignes entre gris et blanc.
-\rowcolors{1}{}{gray!8}
-% Reset le compteur de ligne correctement avec tabulary.
-\preto\tabular{\global\rownum=0\relax}
-
-% Ignore le tableau de la page de titres
-\makeatletter
-\preto\sphinxmaketitle{\bgroup\def\@rowc@lors{}}
-\appto\sphinxmaketitle{\egroup}
-\makeatother
 
 % Customisation des citations pour les uniformiser avec la version HTML.
 \mdfdefinestyle{QuoteFrame}{

--- a/conf.py
+++ b/conf.py
@@ -268,6 +268,8 @@ latex_show_urls = 'footnote'
 # Show pages for internal refs, useful for printed copies.
 latex_show_pagerefs = True
 
+latex_table_style = ['colorrows']
+
 latex_additional_files = ['_templates/club1.sty', '_templates/packages.sty']
 
 latex_license = _(open('_templates/license.txt', 'r').read().strip()).replace('<', r'\url{').replace('>', '}')

--- a/info/espace-personnel.md
+++ b/info/espace-personnel.md
@@ -69,7 +69,7 @@ il faut créer un **fichier de présentation** appellé `PRESENTATION.md` à la 
 Il est possible de formater son texte en {term}`Markdown`,
 ainsi que de changer son nom d'affichage et la couleur de son bouton.
 
-```{admonition} Voir aussi
+```{seealso}
 Tutoriel : [Comment éditer sa présentation](/tutos/presentation.md)
 ```
 

--- a/info/general.md
+++ b/info/general.md
@@ -107,7 +107,7 @@ Les sauvegardes sont réparties en quatre groupes :
 3. **Postgres** pour les bases de données {logiciel}`PostgreSQL`.
 4. **Userdata** pour les données de l'_espace personnel_ (dossier `home`).
 
-```{admonition} Voir aussi
+```{seealso}
 L'article du journal [Sauvegardes](https://club1.fr/backups/)
 ```
 

--- a/info/infrastructure-materielle.md
+++ b/info/infrastructure-materielle.md
@@ -3,7 +3,7 @@ Infrastructure matérielle
 
 Le serveur est auto-hébergé en France à Pantin.
 
-```{admonition} Voir aussi
+```{seealso}
 Les tickets concernant l'infrastructure matérielle sont regroupés sur le forum
 [sous le tag *hardware*](https://forum.club1.fr/t/hardware).
 ```

--- a/info/politique-de-vie-privee.md
+++ b/info/politique-de-vie-privee.md
@@ -3,7 +3,7 @@ Politique de vie privée
 
 Nos engagements en matière de vie privée.
 
-```{admonition} Voir aussi
+```{seealso}
 Nos engagement dans les [CGU](../cgu.md#nos-engagements)
 ```
 

--- a/outils/aliases.md
+++ b/outils/aliases.md
@@ -72,6 +72,6 @@ pour créer les fichiers et exécuter les commandes.
 Ces actions sont réalisées avec les droits de l'utilisateur correspondant à l'alias s'il existe
 et sinon, sur CLUB1, avec l'utilisateur `nobody` et le {term}`groupe` `mail`.
 
-```{admonition} Voir aussi
+```{seealso}
 La [section "Delivery Rights" de la page local du manuel de Postfix](https://manpages.debian.org/stable/postfix/local.8postfix.en.html#DELIVERY_RIGHTS).
 ```

--- a/outils/dns.md
+++ b/outils/dns.md
@@ -26,7 +26,7 @@ Le transfert des zones est sécurisé avec [TSIG](https://fr.wikipedia.org/wiki/
 et [DNSSEC](https://fr.wikipedia.org/wiki/Domain_Name_System_Security_Extensions) est activé sur le domaine `club1.fr`.
 BIND est également utilisé en tant que résolveur DNS pour le réseau local.
 
-```{admonition} Voir aussi
+```{seealso}
 - [Article du journal à propos du serveur DNS](https://club1.fr/serveur-dns)
 - [Fil du forum à propos de DNSSEC](https://forum.club1.fr/d/7-configurer-dnssec-sur-ns1club1fr)
 - Outils de diagnostic en ligne :

--- a/outils/forum.md
+++ b/outils/forum.md
@@ -9,7 +9,7 @@ Il a pour but de remplir trois rôles principaux :
 - Offrir un canal de discussion asynchrone public,
   permettant à des discussions variées de coexister dans la durée.
 
-```{admonition} Voir aussi
+```{seealso}
 L'article du journal "[Création d'un forum](https://club1.fr/creation-d-un-forum)"
 ```
 

--- a/outils/newsletter.md
+++ b/outils/newsletter.md
@@ -73,7 +73,7 @@ L'édition de ce fichier est également réservée aux membres du {term}`groupe`
 
 L'envoi d'emails automatique pour la gestion des inscriptions tire fortement parti des {term}`alias` de réception.
 
-```{admonition} Voir aussi
+```{seealso}
 Pour l'édition des alias email,
 voir la section [Modifier les alias de réception](./aliases.md#modifier-les-alias-de-réception).
 ```

--- a/services/email.md
+++ b/services/email.md
@@ -29,7 +29,7 @@ on utilise un fichier `.formward+[...]` au lieu du fichier `.forward` de l'adres
 > il faut le faire dans le fichier `.forward+travail`.
 ```
 
-```{admonition} Voir aussi
+```{seealso}
 La documentation officielle de l'option [recipient_delimiter](http://www.postfix.org/postconf.5.html#recipient_delimiter)
 (en anglais)
 ```
@@ -67,7 +67,7 @@ Détails divers
 
 Quelques informations supplémentaires à propos de certains détails du service email de CLUB1.
 
-```{admonition} Voir aussi
+```{seealso}
 L'article du journal [Le(s) serveur(s) email](https://club1.fr/email/)
 ```
 
@@ -121,7 +121,7 @@ en ajoutant son nom d'utilisateur&middot;trice à cette liste !
 Pour mettre fin à une redirection, il suffit de supprimer la ligne correspondante.
 Il est aussi possible de supprimer le fichier pour tout annuler.
 
-```{admonition} Voir aussi
+```{seealso}
 La page de manuel [Postfix local mail delivery](https://www.postfix.org/local.8.html) (en anglais)
 ```
 
@@ -205,7 +205,7 @@ utilisé par {logiciel}`Postfix` pour signer les emails sortants.
 --- [Wikipedia](https://fr.wikipedia.org/wiki/Roundcube),
 [Sources](https://github.com/roundcube/roundcubemail)
 
-```{admonition} Voir aussi
+```{seealso}
 La section [](#client-web)
 ```
 ````

--- a/services/web.md
+++ b/services/web.md
@@ -33,7 +33,7 @@ il faut forcément utiliser un [domaine dédié](#hébergement-avec-un-nom-de-do
 
 C'est l'endroit idéal pour débuter et commencer à mettre en ligne rapidement.
 
-```{admonition} Voir aussi
+```{seealso}
 Le tutoriel "[](/tutos/mes-premiers-pas-sur-le-web.md)"
 pour apprendre à faire son premier site web avec le dossier `static`.
 ```


### PR DESCRIPTION
- build: update Sphinx to unreleased 6.2 version
- latex: update code block styles after Sphinx update to 6.2
- latex: update table styles after Sphinx update to 6.2
- latex: make sphinxseealso styles match HTML theme
- latex: use \sphinxremovefinalcolon instead of mine
- latex: adjust styles of bloc quotes
- docs: utilisation de {seealso} existant dans Sphinx

Pour le moment ce n'est pas mergeable car Sphinx 6.2 n'est pas encore sortie.
Closes #208