### PR TITLE
Premier ajout de la page LDAP

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Install apt packages
-        run: sudo apt-get install --no-install-recommends -y gettext
+        run: sudo apt-get install --no-install-recommends -y gettext graphviz
       - name: Restore pip cache
         uses: actions/cache@v3
         with:
@@ -78,6 +78,7 @@ jobs:
       - name: Install apt packages
         run: >
           sudo apt-get install --no-install-recommends -y
+          graphviz
           latexmk
           texlive-luatex
           texlive-latex-extra

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Install apt packages
         run: >
           sudo apt-get install --no-install-recommends -y
+          graphviz
           gettext
           latexmk
           texlive-luatex

--- a/conf.py
+++ b/conf.py
@@ -57,6 +57,7 @@ extensions = [
     'substring_replace',
     'term_tooltips',
     'index_role',
+    'sphinx.ext.graphviz',
 ]
 
 extensions_optionnal = {
@@ -135,6 +136,10 @@ manpages_url = 'https://manpages.debian.org/{path}.' + language
 
 # Title used for BibTeX citation
 citation_bibtex_title = _('Documentation {CLUB1}')
+
+suppress_warnings = [
+    'epub.unknown_project_files',
+]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/outils/index.md
+++ b/outils/index.md
@@ -10,4 +10,5 @@ maxdepth: 2
 meta-doc
 aliases
 forum
+ldap
 ```

--- a/outils/ldap.md
+++ b/outils/ldap.md
@@ -1,0 +1,74 @@
+Annuaire LDAP
+=============
+
+```{glossary}
+LDAP
+   (_Lightweight Directory Access Protocol_) {term}`Protocole` de service d'annuaire
+   décrivant à la fois un modèle de données et la manière d'interroger et de modifier ces données.
+
+   Un annuaire LDAP est une sorte de base de données
+   avec une structure hierarchique, arborescente,
+   permettant de relier des informations à des noms.
+   En général des comptes ou des groupes d'utilisateurs ou d'ordinateurs,
+   appartenant à une organisation.
+
+   Le schéma de données n'est pas fixé,
+   il faut donc le connaitre, avant de pouvoir interagir avec un annuaire LDAP.
+```
+
+CLUB1 utilise un annuaire {term}`LDAP` pour stocker les comptes de ses membres
+de manière centralisée.
+C'est ce qui permet de mettre en commun les identifiants de connexion
+entre les différents [services membres](/services-membres.md).
+
+
+Détails de configuration
+------------------------
+
+Cette section décrit les spécificités de la configuration de CLUB1.
+
+
+```{graphviz}
+---
+caption: Schéma de données LDAP
+---
+graph LDAP {
+   graph [size = "2.5,2.5"]
+   node [fontname = "monospace"]
+
+   "cn=fr" -- "cn=club1"
+   "cn=club1" -- "ou=People"
+   "cn=club1" -- "ou=Group"
+}
+```
+
+
+Informations de connexion
+-------------------------
+
+L'annuaire LDAP de CLUB1 n'est pas public,
+il est accessible uniquement en local depuis le serveur.
+
+| champ            | valeur              |
+| ---------------- | ------------------- |
+| hôte             | `localhost`         |
+| port             | `389` (par défaut)  |
+| TLS              | non                 |
+
+
+Logiciels
+---------
+
+```{logiciel} slapd
+{term}`Serveur` d'annuaire {term}`LDAP` faisant partie du projet OpenLDAP,
+une implémentation libre du protocole LDAP.
+--- [Wikipedia](https://fr.wikipedia.org/wiki/OpenLDAP),
+[Sources](https://git.openldap.org/openldap/openldap)
+```
+
+```{logiciel} nss-pam-ldapd
+{term}`Serveur` connectant les systèmes d'authentification (PAM)
+et de gestion des sources de données (NSS) à l'annuaire {term}`LDAP`.
+--- [Site](https://arthurdejong.org/nss-pam-ldapd/),
+[Sources](https://arthurdejong.org/git/nss-pam-ldapd/)
+```

--- a/outils/meta-doc.md
+++ b/outils/meta-doc.md
@@ -157,6 +157,10 @@ Sphinx
    C'est l'outil utilisé pour générer la documentation présente.
    --- [Wikipedia](https://fr.wikipedia.org/wiki/Sphinx_(g%C3%A9n%C3%A9rateur_de_documentation))
 
+Graphviz
+   Outils de génération de graphes visuels à partir d'une déscription en language DOT.
+   --- [Wikipedia](https://fr.wikipedia.org/wiki/Graphviz)
+
 MyST-Parser
    Extension {term}`Sphinx` permettant la prise en charge du {term}`Markdown`.
 


### PR DESCRIPTION
Un peu succin pour le moment. Mais mieux que rien.

- docs: premier ajout de LDAP (+ config de graphviz)
- docs: ajout de Graphviz à la liste des dépendances de la doc

Pour ce faire une petite idée de ce que donne le graphe décrit ici:
https://github.com/club-1/docs/blob/039e1836ae0ea6fcdfa80be28a42f243f448b116/outils/ldap.md?plain=1#L31-L43

![2023-04-11-215032_491x277_scrot](https://user-images.githubusercontent.com/23519418/231273320-d83adbf3-389f-43b1-9fe0-d0cbeec0a4b5.png)
