### PR TITLE
docs: gandi ne propose plus d'emails fournis avec un nom de domaine

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -28,7 +28,3 @@ CLUB1 fournit **[une seule boîte email](/services/email.md) par compte de membr
 avec une adresse principale et toutes ses [sous-adresses](services/email.md#sous-adresses).
 Il est possible de créer des {term}`alias` personnalisés à la demande,
 mais pas de créer des boîtes de reception supplémentaires.
-
-Si vous louez votre {term}`nom de domaine`, il est probable que votre {term}`registraire`
-(intermédiaire chez qui vous louez le nom de domaine) propose un service d'email inclus.
-Par exemple, [Gandi inclut ce service](https://docs.gandi.net/fr/gandimail/index.html) avec chaque nom de domaine loué.


### PR DESCRIPTION
Voir: <https://forum.club1.fr/d/106>
