### PR TITLE
remaniement de la section service/web

### DIFF
--- a/glossaire.md
+++ b/glossaire.md
@@ -165,13 +165,13 @@ serveur
    [Wikipedia](https://fr.wikipedia.org/wiki/Serveur_informatique)
 
 site Web dynamique
-   Site {term}`Web` dont l'affichage peut varier "de lui même", d'où le nom "dynamique"
+   Site {term}`Web` dont l'affichage peut varier "de lui-même", d'où le nom "dynamique"
    (le distinguant ainsi du {term}`site Web statique`).
    Il contient du code qui va être "executé" pour générer du {term}`HTML`.
    --- [Wikipedia](https://fr.wikipedia.org/wiki/Page_web_dynamique)
 
 site Web statique
-   Site {term}`Web` constitués de fichiers {term}`HTML` dont le contenu ne change pas tant qu'ils n'ont pas été édités.
+   Site {term}`Web` constitué de fichiers {term}`HTML` dont le contenu ne change pas tant qu'ils n'ont pas été édités.
    Ils peuvent être conçus "à la main" ou à l'aide d'un "générateur de site statique".
    Les sites statiques sont une voie intéressante
    pour qui cherche à proposer des sites plus sobres énergétiquement.
@@ -187,7 +187,7 @@ terminal
    --- [Wikipedia](https://fr.wikipedia.org/wiki/Terminal_(informatique))
 
 TLD
-   Top level Domain
+   (_Top level Domain_)
    {term}`Nom de domaine` de premier niveau.
    Par exemple `fr`, `com` ou `org` sont des TLD.
    --- [Wikipedia](https://fr.wikipedia.org/wiki/Domaine_de_premier_niveau)

--- a/glossaire.md
+++ b/glossaire.md
@@ -133,13 +133,12 @@ nom de domaine
    
    En plus de ces informations, un domaine peut également avoir des sous domaines.
 
-
 PHP
    (_PHP Hypertext Preprocessor_) Langage de programmation de haut niveau,
    principalement utilisé pour produire des pages {term}`Web` de manière dynamique
    en générant du code {term}`HTML`.
    Son acronyme signifiait à l'origine "_Personnal Home Page_"
-   et c'est justement le langage que CLUB1 met en avant pour la création de [sites Web dynamiques](./services/web.md#sites-web-dynamiques).
+   et c'est justement le langage que CLUB1 met en avant pour la création de {term}`site Web dynamique`.
    --- [Wikipedia](https://fr.wikipedia.org/wiki/PHP)
 
 protocole
@@ -165,13 +164,13 @@ serveur
    serveurs sont installés (ex : le serveur CLUB1). ---
    [Wikipedia](https://fr.wikipedia.org/wiki/Serveur_informatique)
 
-site dynamyque
+site Web dynamique
    Site {term}`Web` dont l'affichage peut varier "de lui même", d'où le nom "dynamique"
-   (le distinguant ainsi du {term}`site statique`).
+   (le distinguant ainsi du {term}`site Web statique`).
    Il contient du code qui va être "executé" pour générer du {term}`HTML`.
    --- [Wikipedia](https://fr.wikipedia.org/wiki/Page_web_dynamique)
 
-site statique
+site Web statique
    Site {term}`Web` constitués de fichiers {term}`HTML` dont le contenu ne change pas tant qu'ils n'ont pas été édités.
    Ils peuvent être conçus "à la main" ou à l'aide d'un "générateur de site statique".
    Les sites statiques sont une voie intéressante

--- a/glossaire.md
+++ b/glossaire.md
@@ -121,6 +121,19 @@ Markdown
    ce qui le rend plus agréable à lire et à écrire pour un humain. ---
    [Wikipedia](https://fr.wikipedia.org/wiki/Markdown)
 
+nom de domaine
+   Identifiant de domaine {term}`Internet`,
+   facile à lire et à retenir par un être humain.
+
+   > Par exemple : `club1.fr`, `impots.gouv.fr`, et `fr` sont des noms de domaine.
+
+   Un domaine permet d'associer des informations à un nom.
+   Parmi ces informations, la plus importante est l'{term}`adresse IP` de l'ordinateur associé à ce domaine.
+   Un nom de domaine est donc souvent utilisé comme un {term}`alias` pour une adresse IP.
+   
+   En plus de ces informations, un domaine peut également avoir des sous domaines.
+
+
 PHP
    (_PHP Hypertext Preprocessor_) Langage de programmation de haut niveau,
    principalement utilisé pour produire des pages {term}`Web` de manière dynamique
@@ -135,6 +148,11 @@ protocole
    ou le comportement collectif de processus ou d'ordinateurs en réseaux.
    --- [Wikipedia](https://fr.wikipedia.org/wiki/Protocole_informatique)
 
+registraire
+   Registraire de {term}`nom de domaine`.
+   Société ou une association gérant la réservation de nom de domaine {term}`Internet`.
+   --- [Wikipedia](https://fr.wikipedia.org/wiki/Registraire_de_nom_de_domaine)
+
 réseau informatique
    Ensemble d'ordinateurs reliés entre eux pour leur permettre d'échanger des données. ---
    [Wikipedia](https://fr.wikipedia.org/wiki/R%C3%A9seau_informatique)
@@ -147,6 +165,19 @@ serveur
    serveurs sont installés (ex : le serveur CLUB1). ---
    [Wikipedia](https://fr.wikipedia.org/wiki/Serveur_informatique)
 
+site dynamyque
+   Site {term}`Web` dont l'affichage peut varier "de lui même", d'où le nom "dynamique"
+   (le distinguant ainsi du {term}`site statique`).
+   Il contient du code qui va être "executé" pour générer du {term}`HTML`.
+   --- [Wikipedia](https://fr.wikipedia.org/wiki/Page_web_dynamique)
+
+site statique
+   Site {term}`Web` constitués de fichiers {term}`HTML` dont le contenu ne change pas tant qu'ils n'ont pas été édités.
+   Ils peuvent être conçus "à la main" ou à l'aide d'un "générateur de site statique".
+   Les sites statiques sont une voie intéressante
+   pour qui cherche à proposer des sites plus sobres énergétiquement.
+   --- [Wikipedia](https://fr.wikipedia.org/wiki/Page_web_statique)
+
 terminal
    En informatique, un terminal était à l'origine un appareil constitué d'un moniteur et d'un clavier,
    permettant à un&middot;e humain&middot;e d'interagir avec un ordinateur partagé distant.
@@ -155,6 +186,12 @@ terminal
    De nos jours, on utilise souvent le mot "terminal" comme raccourci pour désigner un "émulateur de terminal".
    Il s'agit d'un logiciel recréant l'interface en ligne de commande ({term}`CLI`) de ce materiel.
    --- [Wikipedia](https://fr.wikipedia.org/wiki/Terminal_(informatique))
+
+TLD
+   Top level Domain
+   {term}`Nom de domaine` de premier niveau.
+   Par exemple `fr`, `com` ou `org` sont des TLD.
+   --- [Wikipedia](https://fr.wikipedia.org/wiki/Domaine_de_premier_niveau)
 
 TLS
    (_Transport Layer Security_) Protocole permettant de sécuriser les échanges

--- a/info/espace-personnel.md
+++ b/info/espace-personnel.md
@@ -54,7 +54,7 @@ Dossier utilisé pour [héberger des dépots de code Git](/services/git.md).
 ### 📁 log
 
 Ce dossier contient l'ensemble des {term}`logs <log>` produits par les services.
-Par exemple ceux des {term}`sites Web dynamiques`.
+Par exemple ceux des {term}`sites Web dynamiques<site Web dynamique>`.
 
 Une rotation est opérée à l'aide de {logiciel}`logrotate` sur les fichiers `*.log` de ce dossier toute les semaines
 et un historique de 15 fichiers par log est conservé.

--- a/info/espace-personnel.md
+++ b/info/espace-personnel.md
@@ -54,7 +54,7 @@ Dossier utilisé pour [héberger des dépots de code Git](/services/git.md).
 ### 📁 log
 
 Ce dossier contient l'ensemble des {term}`logs <log>` produits par les services.
-Par exemple ceux des [sites Web dynamiques](../services/web.md#sites-web-dynamiques).
+Par exemple ceux des {term}`sites Web dynamiques`.
 
 Une rotation est opérée à l'aide de {logiciel}`logrotate` sur les fichiers `*.log` de ce dossier toute les semaines
 et un historique de 15 fichiers par log est conservé.

--- a/info/general.md
+++ b/info/general.md
@@ -119,7 +119,7 @@ Il est possible de vérifier qu'un nom le respecte à l'aide de [regex101](https
 Cet identifiant est principalement utilisé en interne pour la connexion aux services
 et n'est donc pas spécialement visible depuis l'extérieur.
 Il est cependant présent dans l'[adresse email CLUB1](/services/email.md) attribuée par défaut aux membres
-et dans les URLs automatiques comme celles des [sites statiques](../services/web.md#sites-web-statiques)
+et dans les URLs automatiques comme celles des {term}`sites Web statiques<site Web statique>`
 et des [dépôts git](/services/git.md).
 
 ### Modalités des comptes

--- a/outils/meta-doc.md
+++ b/outils/meta-doc.md
@@ -217,7 +217,7 @@ Installation sur *Debian* :
 
 ### Commandes
 
-- Compilation en un site statique dans `_build/html` :
+- Compilation en un {term}`site Web statique` dans `_build/html` :
 
       make html
 

--- a/services/web.md
+++ b/services/web.md
@@ -27,7 +27,7 @@ sur le {term}`Web` à l'adresse `https://static.club1.fr`, par exemple :
 
 ```{warning}
 Le dossier `static` se limite aux {term}`sites Web statiques<site Web statique>`.
-Pour héberger des sites {term}`sites dynamqiues<site Web dynamique>`,
+Pour héberger des sites {term}`sites Web dynamiques<site Web dynamique>`,
 il faut forcément utiliser un [domaine dédié](#hébergement-avec-un-nom-de-domaine-dédié).
 ```
 

--- a/services/web.md
+++ b/services/web.md
@@ -15,10 +15,10 @@ Il y a deux façons d'héberger du contenu qui va être accessible sur le {term}
 - avec [un domaine dédié](#hébergement-avec-un-nom-de-domaine-dédié) *Pour des projets mieux définis.*
 
 
-Dossier `static/`
+Dossier `static`
 -----------------
 
-L'**espace personnel** dispose d'un dossier spécial `static/` à sa racine.
+L'**espace personnel** dispose d'un dossier spécial `static` à sa racine.
 Tous les fichiers et dossiers rangés dedans seront automatiquement publiés
 sur le {term}`Web` à l'adresse `https://static.club1.fr`, par exemple :
 
@@ -35,7 +35,7 @@ C'est l'endroit idéal pour débuter et commencer à mettre en ligne rapidement.
 
 ```{admonition} Voir aussi
 Le tutoriel "[](/tutos/mes-premiers-pas-sur-le-web.md)"
-pour apprendre à faire son premier site web avec le dossier `/static`.
+pour apprendre à faire son premier site web avec le dossier `static`.
 ```
 
 Hébergement avec un nom de domaine dédié
@@ -44,7 +44,7 @@ Hébergement avec un nom de domaine dédié
 Contrairement au dossier `static` qui est à emplacement fixe,
 vous êtes libres de choisir l'emplacement des fichiers qui vont être utilisés.
 
-On vous recommande de créer un dossier dans votre [espace personnel](/info/espace-personnel.md)
+Il est recommandé de créer un dossier dans votre [espace personnel](/info/espace-personnel.md)
 qui servira pour tous vos sites Web.
 À l'intérieur, vous pourrez créer **un dossier par site**.
 Par exemple, ici, on a appelé le dossier pour les projets Web `www` (pour *World Wide Web*) :

--- a/services/web.md
+++ b/services/web.md
@@ -9,43 +9,14 @@ Un compte membre CLUB1 **ne limite pas à un seul site web** !
 Il n'y a pas de limite au nombre de projet web à héberger tant que ça ne sature pas le serveur 😄.
 ```
 
+Il y a deux façons d'héberger du contenu qui va être accessible sur le {term}`Web` avec le serveur :
+
+- via [le dossier `static`](#dossier-static) *C'est l'approche la plus spontanée.*
+- avec [un domaine dédié](#hébergement-avec-un-nom-de-domaine-dédié) *Pour des projets mieux définis.*
 
 
-Types de sites
---------------
-
-
-Il existe deux grands types de sites {term}`Web` : les sites _statiques_,
-constitués de fichiers dont le contenu ne change pas tant qu'ils n'ont pas
-été modifiés et les sites _dynamiques_, dont les fichiers sont exécutés et
-peuvent ainsi produire des résultats différents.
-
-### Sites Web _statiques_
-
-Ce type de site web est constitué uniquement de fichiers que le serveur va servir en fonction des requêtes.
-Cela ne demande presque aucun "travail" au processeur, car il n'y a pas de calcul à effectuer.
-Les sites statiques sont une voie intéressante pour qui cherche à proposer des sites plus sobres énergétiquement.
-
-Pour créer un site web statique, on peut écrire soi-même du code HTML,
-associé avec des images, sons ou vidéos.
-C'est la façon la plus artisanale de faire un site web.
-Elle garantit des styles uniques et originaux et est très efficace pour apprendre comment fonctionne le web.
-
-```{tip}
-- Pour apprendre à coder en HTML et CSS, on recommande souvent le
-[tutoriel OpenClassromm](https://openclassrooms.com/fr/courses/1603881-creez-votre-site-web-avec-html5-et-css3)
-de Mathieu Nebra.
-- Le site [Gossip's Web](https://gossipsweb.net/) (en anglais), recueille des sites "fait à la mains".
-```
-
-Mais cela peut devenir complexe lorsque l'on a beaucoup de contenu à gérer.
-Pour ça il est conseillé de se tourner vers les [générateurs de sites statiques](https://fr.wikipedia.org/wiki/G%C3%A9n%C3%A9rateur_de_site_statique)
-Ces outils peuvent générer les fichiers HTML d'un site, par exemple à partir de fichiers {term}`Markdown`,
-sur votre ordinateur personnel.
-À chaque fois qu'une mise à jour est nécessaire, il n'y a qu'à relancer le processus et
-copier les fichiers ainsi créés sur le serveur.
-
-#### Dossier `static/`
+Dossier `static/`
+-----------------
 
 L'**espace personnel** dispose d'un dossier spécial `static/` à sa racine.
 Tous les fichiers et dossiers rangés dedans seront automatiquement publiés
@@ -54,91 +25,50 @@ sur le {term}`Web` à l'adresse `https://static.club1.fr`, par exemple :
 [`https://static.club1.fr/nicolas/test.html`](https://static.club1.fr/nicolas/test.html)
 --> `/home/nicolas/static/test.html`
 
-Ce dossier est servi par le serveur HTTP {logiciel}`Apache`.
-Il est configuré pour automatiquement générer un _index_ affichant la liste
-des fichiers et dossiers qu'il contient.
-
-Pour ne pas afficher cet index, il est possible soit de créer un fichier
-`index.html` qui contiendra la page à afficher à la place, soit d'ajouter
-un {term}`fichier caché` de configuration Apache `.htaccess` contenant au moins la
-ligne suivante.
-
-```apache
-Options -Indexes
+```{warning}
+Le dossier `static` se limite aux {term}`sites statiques<site statique>`.
+Pour héberger des sites {term}`sites dynamqiues<site dynamqiue>`,
+il faut forcément utiliser un [domaine dédié](#hébergement-avec-un-nom-de-domaine-dédié).
 ```
+
+C'est l'endroit idéal pour débuter et commencer à mettre en ligne rapidement.
 
 ```{admonition} Voir aussi
-Le tutoriel "[](/tutos/mes-premiers-pas-sur-le-web.md)" pour apprendre à faire son premier site web avec le dossier `/static`.
+Le tutoriel "[](/tutos/mes-premiers-pas-sur-le-web.md)"
+pour apprendre à faire son premier site web avec le dossier `/static`.
 ```
 
-### Sites Web _dynamiques_
+Hébergement avec un nom de domaine dédié
+----------------------------------------
 
-Ce type de site web utilise du code logique qui s'exécute sur le serveur.
-Cela peut être via un [C.M.S](https://fr.wikipedia.org/wiki/Syst%C3%A8me_de_gestion_de_contenu).
-Et peut notamment nécessiter l'utilisation de [bases de données SQL](sql.md)
-Pour ces sites web, il faut obligatoirement passer par la création d'un [nom de domaine](#noms-de-domaines).
-Car il n'y a pas de dossier automatique préconfiguré.
+Contrairement au dossier `static` qui est à emplacement fixe,
+vous êtes libres de choisir l'emplacement des fichiers qui vont être utilisés.
 
+On vous recommande de créer un dossier dans votre [espace personnel](/info/espace-personnel.md)
+qui servira pour tout vos sites webs.
+À l'interieur, vous pourrez créer **un dossier par site**.
+Par exemple, ici on a appellé le dossier pour les projets Web `www` (pour *World Wide Web*) :
 
-Noms de domaines
-----------------
-
-La question du {term}`nom de domaine` est un enjeu fort du {term}`Web`.
-
-```{important}
-Il faut distinguer hébergement et location de nom de domaine !
-L'hébergement stocke les fichiers d'un site et les publie sur le {term}`web` à une {term}`adresse IP` spécifique,
-tandis qu'un {term}`nom de domaine` est une interface plus agréable pour les humains,
-sensée pointer vers l'adresse IP d'un serveur.
+```
+📁 www
+    📁 mon-site-pro
+    📁 mon-site-perso
+    📁 blog-famille
 ```
 
-Eh oui ! Ce sont deux notions différentes, même si une grosse partie des hébergeurs mainstream
-vont souvent proposer la location du nom de domaine
-en même temps que la location d'un espace pour les fichiers (hébergement).
+Ensuite, il faut choisir un {term}`nom de domaine` associé à ce site.
+Vous avez deux possibilités :
 
+- [Utiliser un sous domaine de `club1.fr`](#utiliser-un-sous-domaine-de-club1fr) *en mode familial*
+- [Louer un nom de domaine](#louer-un-nom-de-domaine-externe) *Pour faire pro !*
 
-
-```{glossary}
-nom de domaine
-   Identifiant de domaine {term}`Internet`,
-   facile à lire et à retenir par un être humain.
-
-   > Par exemple : `club1.fr`, `impots.gouv.fr`, et `fr` sont des noms de domaine.
-
-   Un domaine permet d'associer des informations à un nom.
-   Parmi ces informations, la plus importante est l'{term}`adresse IP` de l'ordinateur associé à ce domaine.
-   Un nom de domaine est donc souvent utilisé comme un {term}`alias` pour une adresse IP.
-   
-   En plus de ces informations, un domaine peut également avoir des sous domaines.
-
-registraire
-   Registraire de {term}`nom de domaine`.
-   Société ou une association gérant la réservation de nom de domaine {term}`Internet`.
-   --- [Wikipedia](https://fr.wikipedia.org/wiki/Registraire_de_nom_de_domaine)
-
-TLD
-   Top level Domain
-   {term}`Nom de domaine` de premier niveau.
-   Par exemple `fr`, `com` ou `org` sont des TLD.
-   --- [Wikipedia](https://fr.wikipedia.org/wiki/Domaine_de_premier_niveau)
-```
-
-Comme le dit *Stéphane Bortzmeyer* dans [son article sur son blog](https://www.bortzmeyer.org/parties-nom-domaine.html) :
-
-> On entend parfois le terme de « sous-domaine ».
-> Malheureusement, il est souvent utilisé en supposant qu'il y a des domaines
-> qui sont des sous-domaines et d'autres qui seraient des « vrais » domaines.
-> Mais ce n'est pas le cas. Tous les domaines sont des sous-domaines d'un autre
-> (à part le cas particulier de la racine, le début des domaines).
-> Ainsi, `signal.eu.org` est un sous-domaine de `eu.org`, lui-même un sous-domaine de `org`,
-> lui-même sous-domaine de la racine.
 
 ### Utiliser un sous domaine de `club1.fr`
 
 Pour faciliter la création de projets et aider à la spontanéité,
 l'utilisation de **sous-domaines** de `club1.fr` par les membres est encouragée !
 
-Cela a l'avantage d'être gratuit, et de ne nécessiter aucun entretien,
+Cela a l'avantage d'être **gratuit**, et de ne nécessiter **aucun entretien**,
 contrairement à la [location d'un nom de domaine](#louer-un-nom-de-domaine-externe).
 L'inconvénient étant de dépendre de `club1.fr`.
 Cela entraîne aussi une **filiation visible avec CLUB1**,
@@ -175,31 +105,54 @@ ce qui n'est pas anodin. Donc pour l'instant, mollo sur les sous.sous.domaines �
 Il est possible de louer un nom de domaine chez un {term}`registraire`.
 Cela coûte souvent une dizaine d'euros par an, mais cela peut varier en fonction du {term}`TLD` choisi.
 
-Nous recommandons [Gandi.net](https://www.gandi.net/fr/domain), pour son soutient à divers projets libres.
+```{important}
+Il faut distinguer hébergement et location de nom de domaine !
+L'hébergement stocke les fichiers d'un site et les publie sur le {term}`web` à une {term}`adresse IP` spécifique,
+tandis qu'un {term}`nom de domaine` est une interface plus agréable pour les humains,
+sensée pointer vers l'adresse IP d'un serveur.
+```
+
+Il est donc parfaitement possible d'avoir un site Web hébergé
+sur le serveur CLUB1 sans utiliser un sous domaine de `club1.fr`.
 
 Avant d'acheter votre dom de domaine, prenez le temps d'en [discuter](#gestion) !
 Il va y avoir une petite série de réglages à faire
 et ça vaut le coup d'en parler pour que tout se passe bien.
 
 
-Gestion
--------
+### Gestion
 
 Aucune de ces actions n'est automatisée ni accessibles via une interface web.
 Il est donc **nécessaire d'en discuter entre humain&middot;e&middot;s** 🍺 !
 Cela fait partie de l'aspect artisanal et de l'échelle volontairement humaine de la gestion du serveur.
 
-Pour soulager la tâche,
-des [scripts](https://github.com/club-1/hosting) sont là pour faciliter la mise en place technique.
+Pour associer un de vos dossier avec un nom de domaine,
+Il faut envoyer un email à <webmaster@club1.fr> indiquant le chemin de votre dossier et le nom de domaine choisi.
 
-C'est _Nicolas_ qu'il faut contacter pour l'association des domaines avec vos dossiers de sites.
+Par exemple :
 
-Il est possible de le joindre :
-
-- par email : <webmaster@club1.fr>
-- par {term}`matrix` : `@n-peugnet:club1.fr`
+    Bonjour, je souhaiterai que mon dossier "www/mon-site-perso" soit publié à "vacances.club1.fr"
 
 
+Avancé
+------
+
+Quelques techniques liés à l'hébergement de site Web sur le serveur.
+
+### Index des fichiers
+
+Les sites Web sont servi par le serveur HTTP {logiciel}`Apache`.
+Il est configuré pour automatiquement générer un _index_ affichant la liste
+des fichiers et dossiers qu'il contient.
+
+Pour ne pas afficher cet index, il est possible soit de créer un fichier
+`index.html` qui contiendra la page à afficher à la place, soit d'ajouter
+un {term}`fichier caché` de configuration Apache `.htaccess` contenant au moins la
+ligne suivante :
+
+```apache
+Options -Indexes
+```
 
 Logiciels
 ---------

--- a/services/web.md
+++ b/services/web.md
@@ -26,8 +26,8 @@ sur le {term}`Web` à l'adresse `https://static.club1.fr`, par exemple :
 --> `/home/nicolas/static/test.html`
 
 ```{warning}
-Le dossier `static` se limite aux {term}`sites statiques<site statique>`.
-Pour héberger des sites {term}`sites dynamqiues<site dynamqiue>`,
+Le dossier `static` se limite aux {term}`sites Web statiques<site Web statique>`.
+Pour héberger des sites {term}`sites dynamqiues<site Web dynamique>`,
 il faut forcément utiliser un [domaine dédié](#hébergement-avec-un-nom-de-domaine-dédié).
 ```
 
@@ -49,12 +49,10 @@ qui servira pour tout vos sites webs.
 À l'interieur, vous pourrez créer **un dossier par site**.
 Par exemple, ici on a appellé le dossier pour les projets Web `www` (pour *World Wide Web*) :
 
-```
-📁 www
-    📁 mon-site-pro
-    📁 mon-site-perso
-    📁 blog-famille
-```
+    📁 www
+        📁 mon-site-pro
+        📁 mon-site-perso
+        📁 blog-famille
 
 Ensuite, il faut choisir un {term}`nom de domaine` associé à ce site.
 Vous avez deux possibilités :

--- a/services/web.md
+++ b/services/web.md
@@ -45,9 +45,9 @@ Contrairement au dossier `static` qui est à emplacement fixe,
 vous êtes libres de choisir l'emplacement des fichiers qui vont être utilisés.
 
 On vous recommande de créer un dossier dans votre [espace personnel](/info/espace-personnel.md)
-qui servira pour tout vos sites webs.
-À l'interieur, vous pourrez créer **un dossier par site**.
-Par exemple, ici on a appellé le dossier pour les projets Web `www` (pour *World Wide Web*) :
+qui servira pour tous vos sites Web.
+À l'intérieur, vous pourrez créer **un dossier par site**.
+Par exemple, ici, on a appelé le dossier pour les projets Web `www` (pour *World Wide Web*) :
 
     📁 www
         📁 mon-site-pro
@@ -124,8 +124,8 @@ Aucune de ces actions n'est automatisée ni accessibles via une interface web.
 Il est donc **nécessaire d'en discuter entre humain&middot;e&middot;s** 🍺 !
 Cela fait partie de l'aspect artisanal et de l'échelle volontairement humaine de la gestion du serveur.
 
-Pour associer un de vos dossier avec un nom de domaine,
-Il faut envoyer un email à <webmaster@club1.fr> indiquant le chemin de votre dossier et le nom de domaine choisi.
+Pour associer un de vos dossiers avec un nom de domaine,
+il faut envoyer un email à <webmaster@club1.fr> indiquant le chemin de votre dossier et le nom de domaine choisi.
 
 Par exemple :
 
@@ -135,11 +135,11 @@ Par exemple :
 Avancé
 ------
 
-Quelques techniques liés à l'hébergement de site Web sur le serveur.
+Quelques techniques liées à l'hébergement de site Web sur le serveur.
 
 ### Index des fichiers
 
-Les sites Web sont servi par le serveur HTTP {logiciel}`Apache`.
+Les sites Web sont servis par le serveur HTTP {logiciel}`Apache`.
 Il est configuré pour automatiquement générer un _index_ affichant la liste
 des fichiers et dossiers qu'il contient.
 

--- a/tutos/mes-premiers-pas-sur-le-web.md
+++ b/tutos/mes-premiers-pas-sur-le-web.md
@@ -110,7 +110,7 @@ Elle se mettra à jour toute seule si vous rajoutez ou supprimez des fichiers.
 
 ```{note}
 Pour un usage plus avancé, il est possible de désactiver les pages d'index.
-Voir les [services liés au dossier static](../services/web.md#sites-web-statiques)
+Voir les [services liés au dossier static](../services/web.md#index-des-fichiers)
 ```
 
 


### PR DESCRIPTION
- déplacement des définitions dans le glossaire
- ré-organisation des chapitres pour une meilleure progression
- retrait des infos non-essentielles (ton article et pas doc)
- ajout au glossaire des termes "site statique" et "site dynamique"
- exemple de mail pour lier domaine voir <https://forum.club1.fr/d/111>
- exemple d'organisation des dossiers pour sites Web