### PR TITLE
Utilisation d'un symbole NB au lieu d'un emoji

### DIFF
--- a/tutos/premiere-connexion-ssh.md
+++ b/tutos/premiere-connexion-ssh.md
@@ -107,7 +107,7 @@ porte généralement le nom de votre utilisateur sur cet appareil.
 
     📁 <utilisateur>
     ├─ 📁 .ssh
-    │  └─ 📄 known_host    👈
+    │  └─ 📄 known_host    🖜
     ├─ 📁 Documents
     ├─ 📁 Images
     ...

--- a/tutos/premiere-connexion-ssh.md
+++ b/tutos/premiere-connexion-ssh.md
@@ -107,7 +107,7 @@ porte généralement le nom de votre utilisateur sur cet appareil.
 
     📁 <utilisateur>
     ├─ 📁 .ssh
-    │  └─ 📄 known_host    🖜
+    │  └─ 📄 known_host    👈🏽
     ├─ 📁 Documents
     ├─ 📁 Images
     ...


### PR DESCRIPTION
L'emoji n'était pas très facile à voir en jaune sur gris.

Avant :
![2024-05-03-131727_387x145_scrot](https://github.com/club-1/docs/assets/23519418/1a47fa37-252b-4959-8f42-d7be5b8fe30d)

Après :
![2024-05-03-131711_390x150_scrot](https://github.com/club-1/docs/assets/23519418/256bec7c-6673-4adc-84b1-e5f4214c8a29)
