### PR TITLE
Nouvelle page de statut / outil de monitoring

### DIFF
--- a/info/general.md
+++ b/info/general.md
@@ -77,7 +77,9 @@ Cela dit, une disponibilité effective **supérieure à 98%** devrait pouvoir ê
 assurée.
 
 Il est possible de consulter en direct l'état des différents services
-sur [UptimeRobot](https://stats.uptimerobot.com/A84pLI9rlW)
+sur <https://status.club1.fr>.
+Cet outil d'observation des services est hébergé par [RésiLien](https://resilien.fr),
+membre du collectif [CHATONS](https://www.chatons.org), sur un serveur situé à Cremeaux.
 
 Comptes des membres
 -------------------

--- a/services/matrix.md
+++ b/services/matrix.md
@@ -139,7 +139,7 @@ Questions concernant le serveur Matrix de CLUB1
 
 Nous ne garantissons pas une fiabilité à toute épreuve de notre serveur,
 cependant pour se faire un avis, il est possible de consulter
-les [statistiques de disponibilité](https://stats.uptimerobot.com/A84pLI9rlW) du serveur Matrix et de Element.
+les [statistiques de disponibilité](https://status.club1.fr) du serveur Matrix et de Element.
 Des mises-à-jour sont effectuées régulièrement
 pour avoir la dernière version de {logiciel}`Synapse` et {logiciel}`Element`
 et ainsi éviter des bugs ou failles de sécurité.


### PR DESCRIPTION
Offerts par le RésiLien, pour remplacer UptimeRobot