### PR TITLE
Nouveau style pour les définitions de commandes

### DIFF
--- a/_static/club1.css
+++ b/_static/club1.css
@@ -1,9 +1,29 @@
+/* Define some variables */
+:root {
+	--color-highlight: #f1c40f;
+}
+
 /* Override blockquotes style */
 .rst-content blockquote {
 	border-left: #bbb solid 4px;
 	color: #555;
 	margin-left: 0;
 	padding-left: 20px;
+}
+
+/* Override "commande" terms style (using #force fake id to increase specificity) */
+#force,
+dl.commande {
+	dt {
+		background: #222;
+		--color-highlight: #806600 ;
+	}
+	dt span {
+		color: white;
+	}
+	dt a {
+		color: #e7f2fa;
+	}
 }
 
 /* Style links on hover */
@@ -54,8 +74,8 @@ section:target > h5,
 figure:target figcaption,
 .target:target,
 dt:target {
-	background: #F1C40F !important;
-	box-shadow: 0 0 0 2px #F1C40F;
+	background: var(--color-highlight) !important;
+	box-shadow: 0 0 0 2px var(--color-highlight);
 }
 
 /* Fix navbar scroll until bottom */


### PR DESCRIPTION
Uniquement avec le builder html, pour le moment.

Comme proposé dans https://forum.club1.fr/d/157-affiner-la-section-servicessh

![2024-07-26-140224_721x719_scrot](https://github.com/user-attachments/assets/5b582d6b-4eda-4032-91ca-54faf947ec25)

