### PR TITLE
Handle markup in term tooltips

### DIFF
--- a/_ext/term_tooltips.py
+++ b/_ext/term_tooltips.py
@@ -39,6 +39,9 @@ class TooltipTranslator(TextTranslator):
         if 'xref' in node['classes'] or 'term' in node['classes']:
             self.add_text(']')
 
+    def visit_literal_block(self, node: nodes.Element) -> None:
+        self.new_state(indent=3)
+
 
 class TooltipBuilder(DummyBuilder):
     default_translator_class = TooltipTranslator

--- a/conf.py
+++ b/conf.py
@@ -94,7 +94,7 @@ myst_substitutions = {
 myst_url_schemes = ['http', 'https', 'mailto', 'matrix']
 
 # Strip everything after the first emdash in term's tooltips.
-term_tooltips_end_before = '— '
+term_tooltips_end_before = '—'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
By extending Sphinx's TextWriter and dependencies, we can handle the docutils nodes as we wish.

Now, the tables are displayed as clipped text with only their label as a caption, xref and term references are surrounded by square brackets, to see in advance if the definition contains references to other terms.

Some behaviour has been directly inherited from Sphinx's TextWriter, mainly the indentation for some blocks (e.g. the admonitions), the lists should now be displayed properly and the inline code literals are surrounded by straight double quotes.

*Before*:
![Peek 2024-07-29 09-19](https://github.com/user-attachments/assets/f4d42c2c-db14-4add-b7ee-968336e69c3a)

*After*:
![Peek 2024-07-29 09-16](https://github.com/user-attachments/assets/ae5aec53-1d2e-474a-8ddd-c12aeccda48b)