### PR TITLE
ajoute un lien vers la source pour les scripts de compta

### DIFF
--- a/outils/compta.md
+++ b/outils/compta.md
@@ -93,6 +93,7 @@ Elle s'affiche avec l'option `-h`.
 ### Logiciel utilisé
 
 
-````{logiciel} compta
+```{logiciel} compta
 Ensemble de scripts pour afficher ou éditer la comptabilité de club1 via le terminal.
 --- [Sources](https://github.com/club-1/compta)
+```

--- a/outils/compta.md
+++ b/outils/compta.md
@@ -88,3 +88,11 @@ Il faut connaître l'identifiant de la transaction que l'on veut modifier.
 Elles disposent chacunes d'une aide, qui décrit leur fonctionnement.
 Elle s'affiche avec l'option `-h`.
 ```
+
+
+### Logiciel utilisé
+
+
+````{logiciel} compta
+Ensemble de scripts pour afficher ou éditer la comptabilité de club1 via le terminal.
+--- [Sources](https://github.com/club-1/compta)


### PR DESCRIPTION
J'ai remarqué qu'il n'y avait pas de lien vers le repo Git des scripts de compta. Voici donc une proposition d'ajout pour palier à cela.