### PR TITLE
Do not check our own github commits link

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -308,6 +308,7 @@ linkcheck_ignore = [
     r'https://www\.buddyns\.com',
     r'https://www\.eaton\.com',
     r'https://dnssec-analyzer\.verisignlabs\.com',
+    r'https://github\.com/club-1/docs/commits/main/',
 ]
 
 # Allow some redirects.


### PR DESCRIPTION
This endpoint seems to be severly limited by GitHub which slows down the linkcheck jobs by a large mount.

We don't really need to check this URL as we know it will exists as long as we use GitHub to share the docs sources.