### PR TITLE
MAJ de la configuration SPF

### DIFF
--- a/services/email.md
+++ b/services/email.md
@@ -192,6 +192,12 @@ Ces filtres peuvent être édités depuis {logiciel}`Roundcube`.
 --- [Site Web](https://pigeonhole.dovecot.org/), [Sources](https://github.com/dovecot/pigeonhole)
 ```
 
+```{logiciel} SPF-Engine
+{term}`Serveur` de traitement [SPF (_Sender Policy Framework_)](https://fr.wikipedia.org/wiki/Sender_Policy_Framework)
+utilisé par {logiciel}`Postfix` pour vérifier l'origine des emails entrants.
+--- [Sources](https://launchpad.net/spf-engine)
+```
+
 ```{logiciel} PostSRSd
 {term}`Serveur` de traitement SRS (_Sender Rewriting Scheme_)
 permettant à {logiciel}`Postfix` de transférer des emails en restant compatible avec SPF.
@@ -210,9 +216,7 @@ et valider la signature des emails entrants.
 pour valider la politique [DMARC (_Domain-based Message Authentication, Reporting, and Conformance_)](https://fr.wikipedia.org/wiki/DMARC)
 des emails entrants.
 
-Il se base pour cela sur le retour d'{logiciel}`OpenDKIM`
-et sur la validation [SPF (_Sender Policy Framework_)](https://fr.wikipedia.org/wiki/Sender_Policy_Framework)
-qu'il réalise lui-même.
+Il se base pour cela sur le retour de {logiciel}`SPF-Engine` et {logiciel}`OpenDKIM`.
 --- [Site Web](http://www.trusteddomain.org/opendmarc/), [Sources](https://github.com/trusteddomainproject/OpenDMARC)
 ```
 


### PR DESCRIPTION
Finalement j'ai remis SPF-Engine car il log plus d'informations (utile pour le debug) et il permet une configuration plus poussée.