### PR TITLE
Ajout lien vers doc deuxfleurs CNAME à l'Apex

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -64,6 +64,10 @@ il est possible de créer une redirection HTTP automatique
 depuis votre nom de domaine vers le sous-domaine de votre choix.
 ```
 
+```{seealso}
+La [documentation de Deuxfleurs](https://guide.deuxfleurs.fr/services/dns-cname-apex/)
+(un autre hébergeur, membre des CHATONS) apporte plus de détails par rapport à cette limitation.
+```
 
 ### Quel espace est-ce-que j'occupe sur le serveur ?
 


### PR DESCRIPTION
En retournant sur la documentation de Deuxfleurs, je suis tombé sur cette page qui explique plutôt bien le problème que l'on a également avec l'utilisation du CNAME pour les domaines externes.

Je trouvais ça sympa de rajouter ce lien pour les personnes qui voudraient pouvoir creuser à propos de cette limitation.