### PR TITLE
ajoute la commande members

### DIFF
--- a/glossaire.md
+++ b/glossaire.md
@@ -113,11 +113,7 @@ groupe
 
    ```{tip}
    Il est possible de savoir qui est membre d'un groupe sur le serveur
-   depuis un accès {term}`SSH` avec la {term}`commande` suivante :
-
-       members GROUP
-
-   En remplaçant `GROUP` par le groupe voulu. Exemple : `members sudo` ou `members home`.
+   depuis un accès {term}`SSH` avec la {term}`commande` {commande}`members`.
    ```
 
    --- [Wikipedia](https://fr.wikipedia.org/wiki/Groupe_(Unix))

--- a/services/ssh.md
+++ b/services/ssh.md
@@ -127,6 +127,15 @@ Cette commande est un peu intrusive !
 --- Manuel : {manpage}`w.1`
 ```
 
+```{commande} members
+Affiche les membres d'un {term}`groupe` :
+
+    members GROUP
+
+En remplaçant GROUP par le groupe voulu. Exemple : `members sudo` ou `members compta`.
+--- Manuel : {manpage}`members.1`
+```
+
 ````{commande} mailx
 La façon la plus basique d'envoyer un email !
 Cette commande nécessite de rajouter au bout, après un espace, l'email de votre destinataire.


### PR DESCRIPTION
déplace la description de l'usage depuis l'entrée du glossaire "groupe" vers la sélection de commandes de la page SSH.