### PR TITLE
améliore l'astuce pour lancer une commande via SSH

### DIFF
--- a/services/ssh.md
+++ b/services/ssh.md
@@ -95,7 +95,7 @@ Sélection de commandes
 Voici une sélection de {term}`commandes <commande>` pour vous permettre de découvrir le serveur :
 
 ```{tip}
-Appuyez sur {kbd}`Enter` pour lancer une commande depuis le terminal.
+Pour lancer une commande depuis le terminal, tappez son nom, puis appuyez sur {kbd}`Enter`.
 ```
 
 ```{commande} exit


### PR DESCRIPTION
ça parait tellement évident quand on a l'habitude, qu'on n'a même pas écrit qu'il fallait taper le nom de la commande avant d'appuyer sur Enter 😅.